### PR TITLE
Fix exception when missing a result during capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ yardstick = "yardstick.cli.cli:cli"
 
 [tool.poetry]
 name = "yardstick"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tool for comparing the results from vulnerability scanners"
 authors = ["Alex Goodman <alex.goodman@anchore.com>"]
 license = "Apache 2.0"

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -147,7 +147,7 @@ def result_set(
 
         if existing_result_set_obj and not refresh:
             result_state = existing_result_set_obj.get(image=scan_request.image, tool=scan_request.tool)
-            if result_state:
+            if result_state and result_state.config:
                 try:
                     scan_config = store.scan_result.find_one(by_description=result_state.config.path)
                 except RuntimeError:


### PR DESCRIPTION
Found an issue when capturing a new result within a result set that exists but has no existing config.
```  
File "/home/runner/work/vulnerability-match-labels/vulnerability-match-labels/venv/lib/python3.10/site-packages/yardstick/capture.py", line 152, in result_set
    scan_config = store.scan_result.find_one(by_description=result_state.config.path)
AttributeError: 'NoneType' object has no attribute 'path'
```
This PR checks to see if the config exists before accessing it.