### PR TITLE
feat: support loading yardstick tools as plugins

### DIFF
--- a/src/yardstick/tool/__init__.py
+++ b/src/yardstick/tool/__init__.py
@@ -1,6 +1,7 @@
 from typing import Union
 
 from .grype import Grype
+from .plugin import load_plugins
 from .sbom_generator import SBOMGenerator
 from .syft import Syft
 from .vulnerability_scanner import VulnerabilityScanner
@@ -15,3 +16,6 @@ tools = {
 
 def Register(name: str, tool: Union[SBOMGenerator, VulnerabilityScanner]) -> None:
     tools[name] = tool
+
+
+load_plugins()

--- a/src/yardstick/tool/plugin.py
+++ b/src/yardstick/tool/plugin.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
+
+
+def load_plugins():
+    tool_plugins = entry_points(group="yardstick.plugins.tools")
+    logging.warning(tool_plugins)
+
+    for tool in tool_plugins:
+        try:
+            logging.info(f"Loading tool plugin {tool.name}")
+            tool.load()
+        except:  # pylint: disable=bare-except
+            logging.exception(f"Failed loading tool plugin {tool.name}")


### PR DESCRIPTION
Supports loading yardstick tool plugins registered to the `yardstick.plugins.tools` entrypoint group.

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>