### PR TITLE
fix: pass full image identifier to tool.capture

### DIFF
--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -111,7 +111,7 @@ class ScanConfiguration(DataClassYAMLMixin):
     def __post_init__(self):
         self.image_repo = self.image_repo.replace("+", "/")
         if not self.tool_input:
-            self.tool_input = self.image
+            self.tool_input = self.full_image
 
     @property
     def path(self):
@@ -136,6 +136,13 @@ class ScanConfiguration(DataClassYAMLMixin):
     @property
     def image(self):
         return f"{self.image_repo}@{self.image_digest}"
+
+    @property
+    def full_image(self):
+        if self.image_tag == "":
+            return self.image
+
+        return f"{self.image_repo}:{self.image_tag}@{self.image_digest}"
 
     @property
     def image_encoded(self):

--- a/tests/unit/artifact_test.py
+++ b/tests/unit/artifact_test.py
@@ -138,7 +138,7 @@ def test_scan_configuration():
     assert s.image_tag == "stuff"
     assert s.tool_name == "grype"
     assert s.tool_version == "main"
-    assert s.tool_input == "docker.io/place/ubuntu@sha256:123"
+    assert s.tool_input == "docker.io/place/ubuntu:stuff@sha256:123"
     assert s.timestamp == datetime.fromisoformat(ts_rfc3339)
     assert s.timestamp_rfc3339 == ts_rfc3339
     assert s.tool == "grype@main"


### PR DESCRIPTION
Pass the full image identifier to the `capture` function for a tool.  The current implementation does not pass in the tag portion of the identifier; however, there will be some tool implementations that require tag to be present.  Both `syft` and `grype` support passing the full image identifier, so this shouldn't break any existing tools and will enable support for future tools like `anchorectl`

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>