### PR TITLE
fix: warning->debug for logging of discovered tool plugin entrypoints

### DIFF
--- a/src/yardstick/tool/plugin.py
+++ b/src/yardstick/tool/plugin.py
@@ -9,7 +9,7 @@ else:
 
 def load_plugins():
     tool_plugins = entry_points(group="yardstick.plugins.tools")
-    logging.warning(tool_plugins)
+    logging.debug(f"discovered plugin entrypoints: {tool_plugins}")
 
     for tool in tool_plugins:
         try:


### PR DESCRIPTION
Signed-off-by: Weston Steimel <weston.steimel@anchore.com>