### PR TITLE
refactor: move fullentry parsing logic to specific tool implementation

### DIFF
--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 
 from yardstick import artifact, store
-from yardstick.tool import sbom_generator, tools, vulnerability_scanner
+from yardstick.tool import get_tool, sbom_generator, vulnerability_scanner
 
 
 class Timer:
@@ -23,7 +23,7 @@ def run_scan(
 ) -> Tuple[artifact.ScanResult, str]:
     logging.debug(f"capturing via run config image={config.image} tool={config.tool}")
 
-    tool_cls = tools[config.tool_name]
+    tool_cls = get_tool(config.tool_name)
     if not tool_cls:
         raise RuntimeError(f"unknown tool: {config.tool_name}")
 
@@ -65,7 +65,7 @@ def run_scan(
 def intake(config: artifact.ScanConfiguration, raw_results: str) -> artifact.ScanResult:
     logging.info(f"capturing via intake config={config}")
 
-    tool_cls = tools[config.tool_name]
+    tool_cls = get_tool(config.tool_name)
     if not tool_cls:
         raise RuntimeError(f"unknown tool: {config.tool_name}")
 

--- a/src/yardstick/cli/explore/image_labels/label_manager.py
+++ b/src/yardstick/cli/explore/image_labels/label_manager.py
@@ -22,7 +22,7 @@ from yardstick import artifact, comparison, store
 from yardstick.cli.explore.image_labels.history import Command, History
 from yardstick.cli.explore.result import MatchCollection
 from yardstick.label import find_labels_for_match
-from yardstick.utils import dig
+from yardstick.tool import tools
 
 # a set of unique locks for each object
 _locks: Dict[int, Lock] = defaultdict(Lock)
@@ -139,10 +139,11 @@ class LabelManager:
             entries: List[MatchSelectEntry] = []
 
             for match in all_matches:
-                ty = dig(match.fullentry, "artifact", "type", default=dig(match.fullentry, "package_type", default=None))
+                t = tools[match.config.tool_name]
+                package_type = t.parse_package_type(match.fullentry)
                 row = [match.vulnerability.id, f"{match.package.name} @ {match.package.version}"]
-                if ty:
-                    row.append(ty)
+                if package_type and package_type != "unknown":
+                    row.append(package_type)
                 table.append(row)
 
             rows = tabulate(table, tablefmt="plain").split("\n")

--- a/src/yardstick/cli/explore/image_labels/label_manager.py
+++ b/src/yardstick/cli/explore/image_labels/label_manager.py
@@ -22,7 +22,7 @@ from yardstick import artifact, comparison, store
 from yardstick.cli.explore.image_labels.history import Command, History
 from yardstick.cli.explore.result import MatchCollection
 from yardstick.label import find_labels_for_match
-from yardstick.tool import tools
+from yardstick.tool import get_tool
 
 # a set of unique locks for each object
 _locks: Dict[int, Lock] = defaultdict(Lock)
@@ -139,7 +139,7 @@ class LabelManager:
             entries: List[MatchSelectEntry] = []
 
             for match in all_matches:
-                t = tools[match.config.tool_name]
+                t = get_tool(match.config.tool_name)
                 package_type = t.parse_package_type(match.fullentry)
                 row = [match.vulnerability.id, f"{match.package.name} @ {match.package.version}"]
                 if package_type and package_type != "unknown":

--- a/src/yardstick/cli/explore/result.py
+++ b/src/yardstick/cli/explore/result.py
@@ -12,17 +12,17 @@ from pygments.lexers.data import JsonLexer
 from pygments.styles.monokai import MonokaiStyle
 
 from yardstick import artifact
-from yardstick.tool import tools
+from yardstick.tool import get_tool
 
 
 def display_match_table_row(match: artifact.Match) -> str:
-    t = tools[match.config.tool_name]
+    t = get_tool(match.config.tool_name)
     package_type = t.parse_package_type(match.fullentry)
     return f"{match.vulnerability.id:20} {match.package.name}@{match.package.version} {package_type}"
 
 
 def display_match(match: artifact.Match) -> str:
-    t = tools[match.config.tool_name]
+    t = get_tool(match.config.tool_name)
     package_type = t.parse_package_type(match.fullentry)
     pkg = f"{match.package.name}@{match.package.version}"
     return f"match vuln='{match.vulnerability.id}', cve='{match.vulnerability.cve_id}', package='{pkg}', type='{package_type}', id='{match.ID}'"
@@ -52,7 +52,7 @@ class MatchCollection:
             filter_text = filter_text.lower()
 
             def condition(match: artifact.Match) -> bool:
-                t = tools[match.config.tool_name]
+                t = get_tool(match.config.tool_name)
                 package_type = t.parse_package_type(match.fullentry)
 
                 return (

--- a/src/yardstick/cli/explore/result.py
+++ b/src/yardstick/cli/explore/result.py
@@ -11,20 +11,21 @@ from prompt_toolkit.validation import ValidationError, Validator
 from pygments.lexers.data import JsonLexer
 from pygments.styles.monokai import MonokaiStyle
 
-from yardstick import artifact, utils
+from yardstick import artifact
+from yardstick.tool import tools
 
 
 def display_match_table_row(match: artifact.Match) -> str:
-    ty = utils.dig(match.fullentry, "artifact", "type", default=utils.dig(match.fullentry, "package_type", default="unknown"))
-
-    return f"{match.vulnerability.id:20} {match.package.name}@{match.package.version} {ty}"
+    t = tools[match.config.tool_name]
+    package_type = t.parse_package_type(match.fullentry)
+    return f"{match.vulnerability.id:20} {match.package.name}@{match.package.version} {package_type}"
 
 
 def display_match(match: artifact.Match) -> str:
-    ty = utils.dig(match.fullentry, "artifact", "type", default=utils.dig(match.fullentry, "package_type", default="unknown"))
-
+    t = tools[match.config.tool_name]
+    package_type = t.parse_package_type(match.fullentry)
     pkg = f"{match.package.name}@{match.package.version}"
-    return f"match vuln='{match.vulnerability.id}', cve='{match.vulnerability.cve_id}', package='{pkg}', type='{ty}', id='{match.ID}'"
+    return f"match vuln='{match.vulnerability.id}', cve='{match.vulnerability.cve_id}', package='{pkg}', type='{package_type}', id='{match.ID}'"
 
 
 class MatchCollection:
@@ -51,14 +52,14 @@ class MatchCollection:
             filter_text = filter_text.lower()
 
             def condition(match: artifact.Match) -> bool:
+                t = tools[match.config.tool_name]
+                package_type = t.parse_package_type(match.fullentry)
+
                 return (
                     filter_text in match.vulnerability.id.lower()
                     or filter_text in match.package.name.lower()
                     or filter_text in match.package.version.lower()
-                    or filter_text
-                    in utils.dig(
-                        match.fullentry, "artifact", "type", default=utils.dig(match.fullentry, "package_type", default="")
-                    )
+                    or filter_text in package_type
                 )
 
         else:

--- a/src/yardstick/comparison.py
+++ b/src/yardstick/comparison.py
@@ -17,6 +17,7 @@ from yardstick.artifact import (  # MatchLabelEntry,
     Vulnerability,
 )
 from yardstick.label import find_labels_for_match, label_entry_matches_image_lineage
+from yardstick.tool import tools as yardstick_tools
 
 
 # AgainstLabels compares a scan result against a set of labels
@@ -656,17 +657,10 @@ class ToolLabelStatsByEcosystem:
                 return "java"
             return e
 
-        def ecosystem(match) -> str:
-            # todo: support more tools
-            t = utils.dig(match.fullentry, "artifact", "type", default="")
-            if t:
-                return normalize_ecosystem(t)
-
-            t = utils.dig(match.fullentry, "package_type", default="")
-            if t:
-                return normalize_ecosystem(t)
-
-            return "unknown"
+        def ecosystem(match: Match) -> str:
+            t = yardstick_tools[match.config.tool_name]
+            package_type = t.parse_package_type(match.fullentry)
+            return normalize_ecosystem(package_type)
 
         tools = set()
         ecosystems = set()

--- a/src/yardstick/comparison.py
+++ b/src/yardstick/comparison.py
@@ -17,7 +17,7 @@ from yardstick.artifact import (  # MatchLabelEntry,
     Vulnerability,
 )
 from yardstick.label import find_labels_for_match, label_entry_matches_image_lineage
-from yardstick.tool import tools as yardstick_tools
+from yardstick.tool import get_tool
 
 
 # AgainstLabels compares a scan result against a set of labels
@@ -658,7 +658,7 @@ class ToolLabelStatsByEcosystem:
             return e
 
         def ecosystem(match: Match) -> str:
-            t = yardstick_tools[match.config.tool_name]
+            t = get_tool(match.config.tool_name)
             package_type = t.parse_package_type(match.fullentry)
             return normalize_ecosystem(package_type)
 

--- a/src/yardstick/tool/__init__.py
+++ b/src/yardstick/tool/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from .grype import Grype
 from .plugin import load_plugins
@@ -16,6 +16,10 @@ tools = {
 
 def Register(name: str, tool: Union[SBOMGenerator, VulnerabilityScanner]) -> None:
     tools[name] = tool
+
+
+def get_tool(name: str) -> Optional[Union[SBOMGenerator, VulnerabilityScanner]]:
+    return tools.get(name.lower())
 
 
 load_plugins()

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -239,5 +239,5 @@ class Grype(VulnerabilityScanner):
         return subprocess.check_output([f"{self.path}/grype", *args], env=self.env(override=env)).decode("utf-8")
 
     @staticmethod
-    def parse_package_type(full_entry: Any) -> str:
+    def parse_package_type(full_entry: Dict[str, Any]) -> str:
         return str(utils.dig(full_entry, "artifact", "type", default=utils.dig(full_entry, "package_type", default="unknown")))

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import git
 import requests
@@ -237,3 +237,7 @@ class Grype(VulnerabilityScanner):
 
     def run(self, *args, env=None) -> str:
         return subprocess.check_output([f"{self.path}/grype", *args], env=self.env(override=env)).decode("utf-8")
+
+    @staticmethod
+    def parse_package_type(full_entry: Any) -> str:
+        return str(utils.dig(full_entry, "artifact", "type", default=utils.dig(full_entry, "package_type", default="unknown")))

--- a/src/yardstick/tool/vulnerability_scanner.py
+++ b/src/yardstick/tool/vulnerability_scanner.py
@@ -1,5 +1,5 @@
 import abc
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from yardstick import artifact
 
@@ -17,4 +17,9 @@ class VulnerabilityScanner(abc.ABC):
     @staticmethod
     @abc.abstractmethod
     def parse(result: str, config: artifact.ScanConfiguration) -> List[artifact.Match]:
+        raise NotImplementedError
+
+    @staticmethod
+    @abc.abstractmethod
+    def parse_package_type(full_entry: Any) -> str:
         raise NotImplementedError

--- a/src/yardstick/tool/vulnerability_scanner.py
+++ b/src/yardstick/tool/vulnerability_scanner.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from yardstick import artifact
 
@@ -21,5 +21,5 @@ class VulnerabilityScanner(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def parse_package_type(full_entry: Any) -> str:
+    def parse_package_type(full_entry: Dict[str, Any]) -> str:
         raise NotImplementedError


### PR DESCRIPTION
Currently there is some tool-specific package type parsing logic scattered around several places in the code.  This change moves the parsing into the tool implementation.