### PR TITLE
refactor: pass both image and tool_input as parameters to capture

### DIFF
--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -110,8 +110,6 @@ class ScanConfiguration(DataClassYAMLMixin):
 
     def __post_init__(self):
         self.image_repo = self.image_repo.replace("+", "/")
-        if not self.tool_input:
-            self.tool_input = self.full_image
 
     @property
     def path(self):

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -39,7 +39,7 @@ def run_scan(
             config.tool_version = installed_version
 
     with Timer() as timer:
-        raw_json = tool.capture(config.tool_input)
+        raw_json = tool.capture(image=config.full_image, tool_input=config.tool_input)
         result = tool.parse(raw_json, config=config)
 
     # patch the start time onto the configuration before writing it to the store

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -230,10 +230,10 @@ class Grype(VulnerabilityScanner):
             results.append(match)
         return results
 
-    def capture(self, image: str) -> str:
-        logging.debug(f"running grype with input={image}")
-
-        return self.run("-o", "json", image)
+    def capture(self, image: str, tool_input: Optional[str]) -> str:
+        i = image if tool_input is None else tool_input
+        logging.debug(f"running grype with input={i}")
+        return self.run("-o", "json", i)
 
     def run(self, *args, env=None) -> str:
         return subprocess.check_output([f"{self.path}/grype", *args], env=self.env(override=env)).decode("utf-8")

--- a/src/yardstick/tool/sbom_generator.py
+++ b/src/yardstick/tool/sbom_generator.py
@@ -11,7 +11,7 @@ class SBOMGenerator(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def capture(self, image: str) -> str:
+    def capture(self, image: str, tool_input: Optional[str]) -> str:
         raise NotImplementedError
 
     @staticmethod

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -174,10 +174,10 @@ class Syft(SBOMGenerator):
             results.append(pkg)
         return results
 
-    def capture(self, image: str) -> str:
-        logging.info(f"running syft with input={image}")
-
-        return self.run("-o", "json", image)
+    def capture(self, image: str, tool_input: Optional[str]) -> str:
+        i = image if tool_input is None else tool_input
+        logging.debug(f"running syft with input={i}")
+        return self.run("-o", "json", i)
 
     def run(self, *args) -> str:
         return subprocess.check_output([f"{self.path}/syft", *args], env=self.env()).decode("utf-8")

--- a/src/yardstick/tool/vulnerability_scanner.py
+++ b/src/yardstick/tool/vulnerability_scanner.py
@@ -11,7 +11,7 @@ class VulnerabilityScanner(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def capture(self, image: str) -> str:
+    def capture(self, image: str, tool_input: Optional[str]) -> str:
         raise NotImplementedError
 
     @staticmethod

--- a/tests/unit/artifact_test.py
+++ b/tests/unit/artifact_test.py
@@ -138,7 +138,7 @@ def test_scan_configuration():
     assert s.image_tag == "stuff"
     assert s.tool_name == "grype"
     assert s.tool_version == "main"
-    assert s.tool_input == "docker.io/place/ubuntu:stuff@sha256:123"
+    assert s.tool_input == None
     assert s.timestamp == datetime.fromisoformat(ts_rfc3339)
     assert s.timestamp_rfc3339 == ts_rfc3339
     assert s.tool == "grype@main"


### PR DESCRIPTION
Allow tools to decide how to handle capturing results based on just an image vs some other input such as an SBOM file.

For grype and syft it didn't matter because both types of input were handled the same way; however, for other tools (like anchorectl), the commands will be different and both the image name and path to the sbom will be needed.

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>