### PR TITLE
Add release process

### DIFF
--- a/.github/scripts/trigger-release.sh
+++ b/.github/scripts/trigger-release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eu
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+if ! [ -x "$(command -v gh)" ]; then
+    echo "The GitHub CLI could not be found. To continue follow the instructions at https://github.com/cli/cli#installation"
+    exit 1
+fi
+
+gh auth status
+
+# we need all of the git state to determine the next version. Since tagging is done by
+# the release pipeline it is possible to not have all of the tags from previous releases.
+git fetch --tags
+
+# populates the CHANGELOG.md and VERSION files
+echo "${bold}Generating changelog...${normal}"
+make changelog 2> /dev/null
+
+NEXT_VERSION=$(cat VERSION)
+
+if [[ "$NEXT_VERSION" == "" ||  "${NEXT_VERSION}" == "(Unreleased)" ]]; then
+    echo "Could not determine the next version to release. Exiting..."
+    exit 1
+fi
+
+while true; do
+    read -p "${bold}Do you want to trigger a release for version '${NEXT_VERSION}'?${normal} [y/n] " yn
+    case $yn in
+        [Yy]* ) echo; break;;
+        [Nn]* ) echo; echo "Cancelling release..."; exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+echo "${bold}Kicking off release for ${NEXT_VERSION}${normal}..."
+echo
+gh workflow run release.yaml -f version=${NEXT_VERSION}
+
+echo
+echo "${bold}Waiting for release to start...${normal}"
+sleep 10
+
+set +e
+
+echo "${bold}Head to the release workflow to monitor the release:${normal} $(gh run list --workflow=release.yaml --limit=1 --json url --jq '.[].url')"
+id=$(gh run list --workflow=release.yaml --limit=1 --json databaseId --jq '.[].databaseId')
+gh run watch $id --exit-status || (echo ; echo "${bold}Logs of failed step:${normal}" && GH_PAGER="" gh run view $id --log-failed)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,82 @@
+name: "Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: tag the latest commit on main with the given version (prefixed with v)
+        required: true
+
+jobs:
+  quality-gate:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check if tag already exists
+        # note: this will fail if the tag already exists
+        run: |
+          [[ "${{ github.event.inputs.version }}" == v* ]] || (echo "version '${{ github.event.inputs.version }}' does not have a 'v' prefix" && exit 1)
+          git tag ${{ github.event.inputs.version }}
+
+      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
+      - name: Ensure tagged commit is on main
+        run: |
+          echo "Tag: ${GITHUB_REF##*/}"
+          git fetch origin main
+          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
+
+      - name: Check validation results
+        uses: fountainhead/action-wait-for-check@v1.1.0
+        id: validations
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
+          checkName: "Validations"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Quality gate
+        if: steps.validations.conclusion != 'success'
+        run: |
+          echo "Validations Status: ${{ steps.validations.conclusion }}"
+          false
+
+
+  release:
+    needs: [quality-gate]
+    runs-on: ubuntu-20.04
+    environment: release
+    permissions:
+      contents: write
+      packages: write
+      issues: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # in order to properly resolve the version from git
+          fetch-depth: 0
+
+      - name: Restore tool cache
+        id: tool-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.tmp
+          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
+
+      - name: (cache-miss) Bootstrap tools
+        if: steps.tool-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
+
+      - name: Tag release
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create github release
+        run: |
+          make changelog
+          gh release create ${{ github.event.inputs.version }} -F CHANGELOG.md -t ${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -45,8 +45,10 @@ jobs:
         run: make static-analysis
 
       - name: Run unit tests
-        run: |
-          poetry run pytest
+        run: poetry run pytest
+
+      - name: Build test
+        run: poetry run make build
 
       - name: Run CLI tests
         run: make cli

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+CHANGELOG.md
+VERSION
+.tmp/
+
 .idea/
 scratch/
 /.yardstick/

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,10 @@ This project requires:
 
 Once you have python and poetry installed, get the project bootstrapped:
 
-```
+```bash
+# get basic project tooling
+make bootstrap
+
 # get a persistent virtual environment to work within
 poetry shell
 
@@ -19,8 +22,7 @@ poetry install
 
 [Pre-commit](https://pre-commit.com/) is used to help enforce static analysis checks with git hooks:
 
-```
-
+```bash
 poetry run pre-commit install --hook-type pre-push
 ```
 
@@ -29,6 +31,7 @@ To jump into a poetry-managed virtualenv run `poetry shell`, this will prevent t
 ## Developing
 
 If you want to use a locally-editable copy of yardstick while you develop:
+
 ```bash
 poetry shell
 pip uninstall yardstick  #... if you already have yardstick installed in this virtual env
@@ -36,11 +39,13 @@ pip install -e .
 ```
 
 To run all static-analysis and tests:
+
 ```bash
 make
 ```
 
 Or run them individually:
+
 ```bash
 make static-analysis
 make unit
@@ -48,6 +53,7 @@ make cli
 ```
 
 If you want to see all of the things you can do:
+
 ```bash
 make help
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+TEMP_DIR = ./.tmp
+
+CHRONICLE = $(TEMP_DIR)/chronicle
+GLOW = $(TEMP_DIR)/glow
+
 # formatting support
 BOLD := $(shell tput -T linux bold)
 PURPLE := $(shell tput -T linux setaf 5)
@@ -8,8 +13,23 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 
+CHRONICLE_VERSION = v0.6.0
+GLOW_VERSION = v1.4.1
+
+
+.DEFAULT_GOAL := all
+
 .PHONY: all
 all: static-analysis test ## Run all validations
+
+
+$(TEMP_DIR):
+	mkdir -p $(TEMP_DIR)
+
+.PHONY: bootstrap
+bootstrap: $(TEMP_DIR)  ## Download and install all tooling dependencies
+	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMP_DIR)/ $(CHRONICLE_VERSION)
+	GOBIN="$(abspath $(TEMP_DIR))" go install github.com/charmbracelet/glow@$(GLOW_VERSION)
 
 .PHONY: test
 test: unit cli  ## Run all tests
@@ -25,6 +45,21 @@ unit: ## Run unit tests
 .PHONY: cli
 cli: ## Run CLI tests
 	cd ./tests/cli && make
+
+.PHONY: build
+build:  ## Run build assets
+	git fetch --tags
+	rm -rf dist
+	poetry build
+
+.PHONY: changelog
+changelog:
+	@$(CHRONICLE) -vvv -n --version-file VERSION > CHANGELOG.md
+	@$(GLOW) CHANGELOG.md
+
+.PHONY: release
+release:
+	@.github/scripts/trigger-release.sh
 
 .PHONY: help
 help:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+## Releasing
+
+Yardstick is published as a git tag in the repo, not to PyPI or elsewhere.
+
+## Creating a new release
+
+You can release Yardstick by running `make release` (if you have the appropriate repo permissions).
+
+You do **not** need to use this local trigger script. You can always kick off the release from the GitHub actions UI as a workflow_dispatch, inputting the desired new version for the release. This approach acts as a manual override for the version if `chronicle` is non-functional or the issue/PR labels are not ready but a release is urgently needed. Remember, if you go this approach you will need to check the release notes afterwards and manually tailor as-needed.
+
+## Managing release versions
+
+This project uses [`chronicle`](https://github.com/anchore/chronicle) to determine the next release from the current set of issues closed and PRs merged since the last release. The kind of change is determined by the set of issue labels, for example the `enhancement` label applied to a closed issue will bump the minor version and the label `bug` applied to a closed issue will bump the patch version. See the [default chronicle change definitions](https://github.com/anchore/chronicle#default-github-change-definitions) for more guidance on how labels affect the changelog. PRs can also be directly included, however, they are superseded by any closed issues that are also linked.
+
+The changelog is also generated with chronicle, collecting changes of particular kinds together with the issue/PR title acting as the changelog entry summary.
+
+If you close an issue with the label `wont-fix` or `changelog-ignore` then the issue will be excluded from consideration while creating the version and changelog.
+
+Why go this approach? The basic idea is that **if you keep issues and PRs well organized and linked (as should be done anyway) then you get version management and changelogs for free**!
+
+The python package version is managed by [`dunamai`](https://github.com/mtkennerly/dunamai) and derives the answer from a single-source of truth (the git tag) but additionally manages how that version propagates to the `pyproject.toml` and other places in the final build. The version within the `pyproject.toml` in the git repo should remain as `v0.0.0`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -401,14 +401,14 @@ typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""
 
 [[package]]
 name = "identify"
-version = "2.5.15"
+version = "2.5.18"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.15-py2.py3-none-any.whl", hash = "sha256:1f4b36c5f50f3f950864b2a047308743f064eaa6f6645da5e5c780d1c7125487"},
-    {file = "identify-2.5.15.tar.gz", hash = "sha256:c22aa206f47cc40486ecf585d27ad5f40adbfc494a3fa41dc3ed0499a23b123f"},
+    {file = "identify-2.5.18-py2.py3-none-any.whl", hash = "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"},
+    {file = "identify-2.5.18.tar.gz", hash = "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe"},
 ]
 
 [package.extras]
@@ -643,14 +643,14 @@ reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
@@ -705,22 +705,22 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
 
 [package.dependencies]
 typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -959,14 +959,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "66.1.1"
+version = "67.3.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
-    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
+    {file = "setuptools-67.3.2-py3-none-any.whl", hash = "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"},
+    {file = "setuptools-67.3.2.tar.gz", hash = "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012"},
 ]
 
 [package.extras]
@@ -1079,14 +1079,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
@@ -1124,25 +1124,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.17.1"
+version = "20.19.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.17.1-py3-none-any.whl", hash = "sha256:ce3b1684d6e1a20a3e5ed36795a97dfc6af29bc3970ca8dab93e11ac6094b3c4"},
-    {file = "virtualenv-20.17.1.tar.gz", hash = "sha256:f8b927684efc6f1cc206c9db297a570ab9ad0e51c16fa9e45487d36d1905c058"},
+    {file = "virtualenv-20.19.0-py3-none-any.whl", hash = "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"},
+    {file = "virtualenv-20.19.0.tar.gz", hash = "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
 importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.8\""}
-platformdirs = ">=2.4,<3"
+platformdirs = ">=2.4,<4"
 
 [package.extras]
-docs = ["proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-argparse (>=0.3.2)", "sphinx-rtd-theme (>=1)", "towncrier (>=22.8)"]
-testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
+test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23)", "pytest (>=7.2.1)", "pytest-env (>=0.8.1)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "wcwidth"
@@ -1232,18 +1232,18 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.11.0"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.11.0-py3-none-any.whl", hash = "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa"},
-    {file = "zipp-3.11.0.tar.gz", hash = "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ yardstick = "yardstick.cli.cli:cli"
 
 [tool.poetry]
 name = "yardstick"
-version = "0.1.2"
+version = "0.0.0" # note: this is automagically managed -- no need to manually change this
 description = "Tool for comparing the results from vulnerability scanners"
 authors = ["Alex Goodman <alex.goodman@anchore.com>"]
 license = "Apache 2.0"
@@ -36,8 +36,11 @@ autoflake = "^2.0"
 tox = "^4.4.5"
 
 [build-system]
-requires = ["poetry-core>=1.3.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.3.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
 
 [tool.isort]
 # all settings suggested by black: https://black.readthedocs.io/en/stable/compatible_configs.html


### PR DESCRIPTION
Today there is no release process, only merging PRs with the `version` field bumped manually. This PR adds an initial process with the following changes:
- Adds `make release` target for triggering a release locally and tagging a git commit with a specific version within the workflow. The workflow also creates a github release with release notes in a changelog format.
- Adds a chronicle-driven changelog generation process based on issue and PR labels.
- Automatically versions builds with the poetry-dynamic-versioning poetry plugin (stays at 0.0.0 in the codebase).