### PR TITLE
Allow grype installations to accept alternate repo

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -291,6 +291,25 @@ files = [
 ]
 
 [[package]]
+name = "dataclass-wizard"
+version = "0.22.2"
+description = "Marshal dataclasses to/from JSON. Use field properties with initial values. Construct a dataclass schema with JSON input."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "dataclass-wizard-0.22.2.tar.gz", hash = "sha256:211f842e5e9a8ace50ba891ef428cd78c82579fb98024f80f3e630ca8d1946f6"},
+    {file = "dataclass_wizard-0.22.2-py2.py3-none-any.whl", hash = "sha256:49be36ecc64bc5a1e9a35a6bad1d71d33b6b9b06877404931a17c6a3a6dfbb10"},
+]
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4.2", markers = "python_version <= \"3.9\""}
+
+[package.extras]
+timedelta = ["pytimeparse (>=1.1.7)"]
+yaml = ["PyYAML (>=5.3)"]
+
+[[package]]
 name = "dataclasses-json"
 version = "0.5.7"
 description = "Easily serialize dataclasses to and from JSON"
@@ -560,28 +579,6 @@ files = [
 marshmallow = ">=2.0.0"
 
 [[package]]
-name = "mashumaro"
-version = "3.5"
-description = "Fast serialization framework on top of dataclasses"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "mashumaro-3.5-py3-none-any.whl", hash = "sha256:2fc228b9153aef6273c86a33b049b819d62abea850ad60ba54b8801a546720a3"},
-    {file = "mashumaro-3.5.tar.gz", hash = "sha256:0b33fda1cd711950eab2bc0f28fecdf72b5ce80724095927146f70de23929451"},
-]
-
-[package.dependencies]
-pyyaml = {version = ">=3.13", optional = true, markers = "extra == \"yaml\""}
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-msgpack = ["msgpack (>=0.5.6)"]
-orjson = ["orjson"]
-toml = ["tomli (>=1.1.0)", "tomli-w (>=1.0)"]
-yaml = ["pyyaml (>=3.13)"]
-
-[[package]]
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
@@ -591,6 +588,18 @@ python-versions = ">=3.6"
 files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
 ]
 
 [[package]]
@@ -895,7 +904,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1278,4 +1287,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "2142425dc76ee613585ffa8343b34ed4501f913fce53161cf25b08793833552c"
+content-hash = "002e3a091d651a566eaca89beb522a4cc275acd4e472894821896d636765bc4b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -904,7 +904,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1287,4 +1287,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "002e3a091d651a566eaca89beb522a4cc275acd4e472894821896d636765bc4b"
+content-hash = "ce6375798174fa46a5aa3a804fabffe6e12a9c5d20cd0251b44dc65d99609fe5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ Pygments = "^2.8.1"
 requests = "^2.25.1"
 GitPython = "^3.1.15"
 rfc3339 = "^6.2"
-mashumaro = {extras = ["yaml"], version = "^3.5"}
 Colr = "^0.9.1"
 omitempty = "^0.1.1"
 importlib-metadata = "^6.0.0"
+mergedeep = "^1.3.4"
+dataclass-wizard = "^0.22.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest-mock = "^3.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ omitempty = "^0.1.1"
 importlib-metadata = "^6.0.0"
 mergedeep = "^1.3.4"
 dataclass-wizard = "^0.22.2"
+pyyaml = "^6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest-mock = "^3.10.0"

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -41,7 +41,7 @@ class Tool:
     label: Optional[str] = None
 
     def __post_init__(self):
-        name, version = self.tool.split("@", 1)
+        name, version = self.tool.split("@")
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "version", version)
 

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -12,7 +12,6 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from dataclasses_json import config, dataclass_json
-from mashumaro.mixins.yaml import DataClassYAMLMixin
 
 from yardstick.utils import grype_db, is_cve_vuln_id, parse_year_from_id
 
@@ -35,14 +34,14 @@ def get_image_digest(image: str) -> str:
 
 
 @dataclass(frozen=True, eq=True)
-class Tool(DataClassYAMLMixin):
+class Tool:
     tool: str
     name: str = field(init=False)
     version: str = field(init=False)
     label: Optional[str] = None
 
     def __post_init__(self):
-        name, version = self.tool.split("@")
+        name, version = self.tool.split("@", 1)
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "version", version)
 
@@ -109,7 +108,7 @@ class Image:
 # note: we cannot freeze this class since the tool installation may add additional metadata
 @dataclass_json
 @dataclass(frozen=False, eq=True, order=True)
-class ScanConfiguration(DataClassYAMLMixin):
+class ScanConfiguration:
     image_repo: str
     image_digest: str
     tool_name: str
@@ -201,7 +200,7 @@ tool:\t{self.tool}"""
 
 
 @dataclass(frozen=True, eq=True, order=True)
-class ScanMetadata(DataClassYAMLMixin):
+class ScanMetadata:
     timestamp: datetime = field(
         metadata=config(
             encoder=lambda dt: dt.isoformat(),
@@ -213,7 +212,7 @@ class ScanMetadata(DataClassYAMLMixin):
 
 
 @dataclass(frozen=True, eq=True, order=True)
-class Package(DataClassYAMLMixin):
+class Package:
     name: str
     version: str
 
@@ -222,7 +221,7 @@ class Package(DataClassYAMLMixin):
 
 
 @dataclass(frozen=True, eq=True, order=True)
-class Vulnerability(DataClassYAMLMixin):
+class Vulnerability:
     id: str
     cve_id: Optional[str] = field(default=None, hash=False)
 
@@ -268,7 +267,7 @@ class DTEncoder(json.JSONEncoder):
 # note: cannot use order=True since lt/gt/etc require not including the fullentry dict
 @dataclass_json
 @dataclass(frozen=True)
-class Match(DataClassYAMLMixin):
+class Match:
     vulnerability: Vulnerability
     package: Package
     fullentry: Optional[Dict[str, Any]] = field(default=None, hash=False)
@@ -313,7 +312,7 @@ class Match(DataClassYAMLMixin):
 
 @dataclass_json
 @dataclass(frozen=False, eq=True, order=True)
-class ScanResult(DataClassYAMLMixin):
+class ScanResult:
     config: ScanConfiguration
     matches: Optional[List[Match]] = field(default=None)
     packages: Optional[List[Package]] = field(default=None)
@@ -501,7 +500,7 @@ id: {self.ID}
 
 
 @dataclass()
-class ScanRequest(DataClassYAMLMixin):
+class ScanRequest:
     image: str
     tool: str
     label: Optional[str] = None

--- a/src/yardstick/cli/cli.py
+++ b/src/yardstick/cli/cli.py
@@ -1,7 +1,11 @@
+import dataclasses
+import enum
 import logging
+from typing import Any
 
 import click
 import pkg_resources
+import yaml
 
 from yardstick import store
 from yardstick.cli import config, label, result
@@ -56,8 +60,57 @@ def cli(ctx, verbose: bool, config_path: str):
 @click.pass_obj
 def show_config(cfg: config.Application):
     logging.info("showing application config")
-    print()
-    print(cfg.to_yaml())
+
+    class IndentDumper(yaml.Dumper):  # pylint: disable=too-many-ancestors
+        def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:  # noqa: ARG002
+            return super().increase_indent(flow, False)
+
+    def enum_asdict_factory(data: list[tuple[str, Any]]) -> dict[Any, Any]:
+        # prevents showing oddities such as
+        #
+        #   wolfi:
+        #       request_timeout: 125
+        #       runtime:
+        #       existing_input: !!python/object/apply:vunnel.provider.InputStatePolicy
+        #           - keep
+        #       existing_results: !!python/object/apply:vunnel.provider.ResultStatePolicy
+        #           - delete-before-write
+        #       on_error:
+        #           action: !!python/object/apply:vunnel.provider.OnErrorAction
+        #           - fail
+        #           input: !!python/object/apply:vunnel.provider.InputStatePolicy
+        #           - keep
+        #           results: !!python/object/apply:vunnel.provider.ResultStatePolicy
+        #           - keep
+        #           retry_count: 3
+        #           retry_delay: 5
+        #       result_store: !!python/object/apply:vunnel.result.StoreStrategy
+        #           - flat-file
+        #
+        # and instead preferring:
+        #
+        #   wolfi:
+        #       request_timeout: 125
+        #       runtime:
+        #       existing_input: keep
+        #       existing_results: delete-before-write
+        #       on_error:
+        #           action: fail
+        #           input: keep
+        #           results: keep
+        #           retry_count: 3
+        #           retry_delay: 5
+        #       result_store: flat-file
+
+        def convert_value(obj: Any) -> Any:
+            if isinstance(obj, enum.Enum):
+                return obj.value
+            return obj
+
+        return {k: convert_value(v) for k, v in data}
+
+    cfg_dict = dataclasses.asdict(cfg, dict_factory=enum_asdict_factory)
+    print(yaml.dump(cfg_dict, Dumper=IndentDumper, default_flow_style=False))
 
 
 @cli.command(name="version", help="show the installed version of yardstick")

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -8,6 +8,8 @@ import shutil
 from collections import defaultdict
 from typing import List, Optional, Tuple
 
+from dataclass_wizard import fromdict
+
 from yardstick import artifact
 from yardstick.store import config as store_config
 from yardstick.store import naming, tool
@@ -123,7 +125,7 @@ def find(
         image_tool_dir = os.path.dirname(os.path.dirname(metadata_file))
         with open(metadata_file, "r", encoding="utf-8") as fd:
             metadata_dict = json.load(fd)
-            cfg = artifact.ScanConfiguration.from_dict(metadata_dict["config"])
+            cfg = fromdict(artifact.ScanConfiguration, metadata_dict["config"])
 
             if is_id and cfg.ID != by_description:
                 continue
@@ -214,7 +216,7 @@ def load(
     results = {**metadata_dict, **keys}
 
     # pylint: disable=no-member
-    result_obj: artifact.ScanResult = artifact.ScanResult.from_dict(results)
+    result_obj: artifact.ScanResult = fromdict(artifact.ScanResult, results)
 
     # TODO: allow for searching for more results until there is a matching digest
     if config.image_digest and result_obj.config.image_digest != config.image_digest:
@@ -239,7 +241,7 @@ def list_all_configs(store_root: str = None) -> List[artifact.ScanConfiguration]
     for metadata_file in list_all_metadata_json(store_root=store_root):
         with open(metadata_file, "r", encoding="utf-8") as metadata_file:
             metadata_dict = json.load(metadata_file)
-            results.append(artifact.ScanConfiguration.from_dict(metadata_dict["config"]))
+            results.append(fromdict(artifact.ScanConfiguration, metadata_dict["config"]))
     return sorted(results)
 
 

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -8,8 +8,6 @@ import shutil
 from collections import defaultdict
 from typing import List, Optional, Tuple
 
-from dataclass_wizard import fromdict
-
 from yardstick import artifact
 from yardstick.store import config as store_config
 from yardstick.store import naming, tool
@@ -125,7 +123,7 @@ def find(
         image_tool_dir = os.path.dirname(os.path.dirname(metadata_file))
         with open(metadata_file, "r", encoding="utf-8") as fd:
             metadata_dict = json.load(fd)
-            cfg = fromdict(artifact.ScanConfiguration, metadata_dict["config"])
+            cfg = artifact.ScanConfiguration.from_dict(metadata_dict["config"])  # pylint: disable=no-member
 
             if is_id and cfg.ID != by_description:
                 continue
@@ -216,7 +214,7 @@ def load(
     results = {**metadata_dict, **keys}
 
     # pylint: disable=no-member
-    result_obj: artifact.ScanResult = fromdict(artifact.ScanResult, results)
+    result_obj: artifact.ScanResult = artifact.ScanResult.from_dict(results)
 
     # TODO: allow for searching for more results until there is a matching digest
     if config.image_digest and result_obj.config.image_digest != config.image_digest:
@@ -241,7 +239,7 @@ def list_all_configs(store_root: str = None) -> List[artifact.ScanConfiguration]
     for metadata_file in list_all_metadata_json(store_root=store_root):
         with open(metadata_file, "r", encoding="utf-8") as metadata_file:
             metadata_dict = json.load(metadata_file)
-            results.append(fromdict(artifact.ScanConfiguration, metadata_dict["config"]))
+            results.append(artifact.ScanConfiguration.from_dict(metadata_dict["config"]))  # pylint: disable=no-member
     return sorted(results)
 
 

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -78,6 +78,15 @@ class Grype(VulnerabilityScanner):
         logging.debug(f"installing grype version={version!r} from git")
         tool_exists = False
 
+        repo_url = "github.com/anchore/grype"
+        if version.startswith("github.com"):
+            repo_url = version
+            if "@" in version:
+                version = version.split("@")[1]
+                repo_url = repo_url.split("@")[0]
+            else:
+                version = "main"
+
         if not use_cache and path:
             shutil.rmtree(path, ignore_errors=True)
 
@@ -97,10 +106,10 @@ class Grype(VulnerabilityScanner):
                 logging.error(f"failed to open existing grype repo at {repo_path!r}")
                 raise
         else:
-            logging.debug("cloning the grype git repo")
+            logging.debug(f"cloning the grype git repo: {repo_url!r}")
             # clone the repo
             os.makedirs(repo_path)
-            repo = git.Repo.clone_from("https://github.com/anchore/grype.git", repo_path)
+            repo = git.Repo.clone_from(f"https://{repo_url}.git", repo_path)
 
         # checkout the ref in question
         repo.git.fetch("origin", version)


### PR DESCRIPTION
Allows for yardstick input such as:

```yaml
...
result-sets:
  pr-vs-latest:
    description: "latest released grype vs grype from the current build"
    matrix:
      images: ...
      tools:
        - name: grype
          version: github.com/wagoodman/grype@main
...
```

enabling referencing forks of grype on different branches.