### PR TITLE
fix: split tool name should have a length limit

### DIFF
--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -41,7 +41,7 @@ class Tool:
     label: Optional[str] = None
 
     def __post_init__(self):
-        name, version = self.tool.split("@")
+        name, version = self.tool.split("@", 1)
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "version", version)
 


### PR DESCRIPTION
Tool version may have a `@` character, thus a length limit is required.