### PR TITLE
Use grype DB from analysis when parsing results (if possible)

### DIFF
--- a/src/yardstick/cli/explore/image_labels/cve_provider.py
+++ b/src/yardstick/cli/explore/image_labels/cve_provider.py
@@ -13,7 +13,6 @@ class CveDescriptions:
         if cve in self.cache:
             return self.cache[cve]
 
-        description = ""
         if not self.grype_db.enabled:
             description = "could not connect to grype db:\n" + self.grype_db.message
         else:

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -252,6 +252,17 @@ class Grype(VulnerabilityScanner):
 
         # patch the config with the db information found
         config.detail["db"] = utils.dig(obj, "descriptor", "db", default={})
+        db_location = config.detail["db"].get("location", None)
+        if db_location:
+            # we should always interpret results with the same DB if the DB is still there (e.g. to support
+            # GHSA to CVE mapping for the latest results) if the DB is not there, we try to fall back to
+            # the DB found on the system (which isn't ideal, but is better than nothing)
+            logging.debug(f"using db location found in results to interpret vulnerability definitions: {db_location!r}")
+            utils.grype_db.use(db_location)
+        else:
+            logging.debug(
+                "no db location found in results, using system grype DB (not ideal and may cause issues with date filtering)"
+            )
 
         for entry in obj["matches"]:
             # TODO: normalize version here


### PR DESCRIPTION
When parsing grype results and using the grype database to find upstream CVEs for vulnerability IDs (say for GHSAs) it's important to try and use the same DB as was used in the analysis. This is not imperative, however, the current behavior is to use the system's grype database, which is overly presumptuous. It could be that the DB is out of date relative to the results, so max-year filtering will not work correctly, or that grype isn't installed at all. This PR changes the behavior to attempt to use a DB in the local yardstick tools directory first before falling back to using the system grype database.

A slightly better enhancement would be to download the specific DB used for analysis, or the latest version directly, and store in a cache directory in `.yardstick`. That can be done in a future effort.