### PR TITLE
Add grype profiles

### DIFF
--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -11,12 +11,7 @@ from yardstick.store import config as store_config
 
 @dataclass()
 class Profiles:
-    data: InitVar[Dict[str, Dict[str, str]]] = None
-
-    def __init__(self, data: Dict[str, Dict[str, str]] = None):
-        if not data:
-            data = {}
-        self.data = data
+    data: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
     def get(self, tool_name: str, profile: str):
         return self.data.get(tool_name, {}).get(profile, {})

--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 import mergedeep

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -8,9 +8,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from dataclasses import dataclass
 import git
 import requests
 
@@ -22,6 +22,7 @@ from yardstick.tool.vulnerability_scanner import VulnerabilityScanner
 class GrypeProfile:
     name: Optional[str] = None
     config_path: Optional[str] = None
+
 
 class Grype(VulnerabilityScanner):
     _latest_version_from_github: Optional[str] = None
@@ -184,9 +185,7 @@ class Grype(VulnerabilityScanner):
             version = fields[0]
             update_db = False
 
-        logging.debug(
-            f"parsed import-db={db_import_path!r} from version={original_version!r} new version={version!r}"
-        )
+        logging.debug(f"parsed import-db={db_import_path!r} from version={original_version!r} new version={version!r}")
         if profile:
             grype_profile = GrypeProfile(**profile)
         else:
@@ -229,9 +228,7 @@ class Grype(VulnerabilityScanner):
                 version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs
             )
         else:
-            tool_obj = cls._install_from_git(
-                version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs
-            )
+            tool_obj = cls._install_from_git(version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs)
 
         # always update the DB, raise exception on failure
         if db_import_path:

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -32,8 +32,6 @@ class Grype(VulnerabilityScanner):
         version_detail: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         profile: Optional[GrypeProfile] = None,
-        # TODO: add support for config profile
-        # based on https://github.com/anchore/yardstick-plugin-anchorectl/blob/55ee39cd420df85ea6622ec2701e2a15880b0e90/src/yardstick_plugin_anchorectl/anchorectl.py#L108
         **kwargs,  # pylint: disable=unused-argument
     ):
         if not profile:

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -43,9 +43,8 @@ class Grype(VulnerabilityScanner):
         self._env = env
         if version_detail:
             self.version_detail = version_detail
-
-        if self.profile and self.profile.name and self.version_detail:
-            self.version_detail += f"+profile={self.profile.name}"
+            if self.profile and self.profile.name:
+                self.version_detail += f"+profile={self.profile.name}"
 
     @staticmethod
     def _install_from_installer(

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -10,12 +10,18 @@ import sys
 import tempfile
 from typing import Any, Dict, List, Optional
 
+from dataclasses import dataclass
 import git
 import requests
 
 from yardstick import artifact, utils
 from yardstick.tool.vulnerability_scanner import VulnerabilityScanner
 
+
+@dataclass(frozen=False)
+class GrypeProfile:
+    name: Optional[str] = None
+    config_path: Optional[str] = None
 
 class Grype(VulnerabilityScanner):
     _latest_version_from_github: Optional[str] = None
@@ -25,12 +31,22 @@ class Grype(VulnerabilityScanner):
         path: str,
         version_detail: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        profile: Optional[GrypeProfile] = None,
+        # TODO: add support for config profile
+        # based on https://github.com/anchore/yardstick-plugin-anchorectl/blob/55ee39cd420df85ea6622ec2701e2a15880b0e90/src/yardstick_plugin_anchorectl/anchorectl.py#L108
         **kwargs,  # pylint: disable=unused-argument
     ):
+        if not profile:
+            profile = GrypeProfile()
+        self.profile = profile
+
         self.path = path
         self._env = env
         if version_detail:
             self.version_detail = version_detail
+
+        if self.profile and self.profile.name and self.version_detail:
+            self.version_detail += f"+profile={self.profile.name}"
 
     @staticmethod
     def _install_from_installer(
@@ -158,6 +174,7 @@ class Grype(VulnerabilityScanner):
         use_cache: Optional[bool] = True,
         update_db: bool = True,
         db_import_path=None,
+        profile: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> "Grype":
         original_version = version
@@ -169,7 +186,13 @@ class Grype(VulnerabilityScanner):
             version = fields[0]
             update_db = False
 
-        logging.debug(f"parsed import-db={db_import_path!r} from version={original_version!r} new version={version!r}")
+        logging.debug(
+            f"parsed import-db={db_import_path!r} from version={original_version!r} new version={version!r}"
+        )
+        if profile:
+            grype_profile = GrypeProfile(**profile)
+        else:
+            grype_profile = GrypeProfile()
 
         if version == "latest":
             if cls._latest_version_from_github:
@@ -204,9 +227,13 @@ class Grype(VulnerabilityScanner):
             r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
             version,
         ):
-            tool_obj = cls._install_from_installer(version=version, path=path, use_cache=use_cache, **kwargs)
+            tool_obj = cls._install_from_installer(
+                version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs
+            )
         else:
-            tool_obj = cls._install_from_git(version=version, path=path, use_cache=use_cache, **kwargs)
+            tool_obj = cls._install_from_git(
+                version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs
+            )
 
         # always update the DB, raise exception on failure
         if db_import_path:
@@ -287,7 +314,11 @@ class Grype(VulnerabilityScanner):
         return self.run("-o", "json", i)
 
     def run(self, *args, env=None) -> str:
-        return subprocess.check_output([f"{self.path}/grype", *args], env=self.env(override=env)).decode("utf-8")
+        cmd = [f"{self.path}/grype", *args]
+        if self.profile and self.profile.config_path:
+            cmd.append("-c")
+            cmd.append(self.profile.config_path)
+        return subprocess.check_output(cmd, env=self.env(override=env)).decode("utf-8")
 
     @staticmethod
     def parse_package_type(full_entry: Dict[str, Any]) -> str:

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -2,9 +2,10 @@ from yardstick.cli import config
 
 
 def test_config(tmp_path):
-    subject = """
+    profile_file = tmp_path / ".yardstick.profiles.yaml"
+    subject = f"""
 store_root: .
-
+profile_path: {profile_file}
 default-max-year: 2021
 
 x-ref:
@@ -45,7 +46,6 @@ test_profile:
     config_path: .abc/xyx.conf
     refresh: false
 """
-    profile_file = tmp_path / ".yardstick.profiles.yaml"
     profile_file.write_text(profile_text)
 
     cfg = config.load(str(file))

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -1,0 +1,15 @@
+from unittest import mock
+
+import pytest
+
+from yardstick.tool.grype import Grype, GrypeProfile
+
+
+def test_grype_profiles():
+    profile_arg = {"name": "test-profile", "config_path": "test-config-path"}
+    profile = GrypeProfile(**profile_arg)
+    with mock.patch("subprocess.check_output") as check_output:
+        check_output.return_value = bytes("test-output", "utf-8")
+        tool = Grype(path="test-path", profile=profile)
+        tool.capture(image="test-image", tool_input=None)
+        assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image", "-c", "test-config-path"]

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -13,3 +13,11 @@ def test_grype_profiles():
         tool = Grype(path="test-path", profile=profile)
         tool.capture(image="test-image", tool_input=None)
         assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image", "-c", "test-config-path"]
+
+
+def test_grype_no_profile():
+    with mock.patch("subprocess.check_output") as check_output:
+        check_output.return_value = bytes("test-output", "utf-8")
+        tool = Grype(path="test-path")
+        tool.capture(image="test-image", tool_input=None)
+        assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image"]


### PR DESCRIPTION
Add named profiles so that a grype config file path can be specified in yardstick config.

## Testing:

Run grype with a profile disables CPE matching, against an artifact known to have some CPE matches:
```
yardstick result capture -r test-no-cpes
2023-06-28 08:28:33,110 [INFO] capturing data result_set=test-no-cpes
2023-06-28 08:28:33,111 [INFO] using existing scan result for tool=syft@v0.84.0 image=docker.io/petabridge/lighthouse@sha256:be3b3df2f548cac599b253d9a8f2dc2d5089e9bea35b976ce22739eb9691d7ff : 5afd81cd-b7d1-411a-b63d-bacb0b126b8e
2023-06-28 08:28:33,111 [INFO] capturing data image=docker.io/petabridge/lighthouse@sha256:be3b3df2f548cac599b253d9a8f2dc2d5089e9bea35b976ce22739eb9691d7ff tool=grype@v0.63.0 profile=no_cpes
 ✔ Vulnerability DB        [no update available]
 ✔ Scanning image...       [104 vulnerabilities]
   ├── 1 critical, 26 high, 8 medium, 8 low, 61 negligible
   └── 21 fixed
```

Run grype with a profile that _enables_ CPE matching, against an artifact known to have some CPE matches:

```
❯ yardstick result capture -r test-cpes   
2023-06-28 08:28:37,998 [INFO] capturing data result_set=test-cpes
2023-06-28 08:28:37,999 [INFO] using existing scan result for tool=syft@v0.84.0 image=docker.io/petabridge/lighthouse@sha256:be3b3df2f548cac599b253d9a8f2dc2d5089e9bea35b976ce22739eb9691d7ff : 0c751b78-ab78-4b79-b081-41d74fbc01ff
2023-06-28 08:28:37,999 [INFO] capturing data image=docker.io/petabridge/lighthouse@sha256:be3b3df2f548cac599b253d9a8f2dc2d5089e9bea35b976ce22739eb9691d7ff tool=grype@v0.63.0 profile=use_cpes
 ✔ Vulnerability DB        [no update available]

 ✔ Scanning image...       [108 vulnerabilities]
   ├── 1 critical, 30 high, 8 medium, 8 low, 61 negligible
   └── 21 fixed
```

Note that 4 more vulnerabilities are found in the second run.