### PR TITLE
Add label stats store

### DIFF
--- a/src/yardstick/__init__.py
+++ b/src/yardstick/__init__.py
@@ -41,6 +41,14 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
 ]:
     descriptions = list(descriptions)
 
+    # this is a description of what was done to the results before comparison
+    # we want to keep this on the comparison to evaluate if the comparison result
+    # can be compared to other comparison results (are they apples to apples).
+    compare_configuration = {
+        "year_max_limit": year_max_limit,
+        "year_from_cve_only": year_from_cve_only,
+    }
+
     if result_set:
         descriptions.extend(store.result_set.load(result_set).descriptions)
 
@@ -67,6 +75,7 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
         *results,
         fuzzy_package_match=fuzzy,
         label_entries=label_entries,
+        compare_configuration=compare_configuration,
     )
 
     return results, label_entries, comparisons_by_result_id, stats_by_image_tool_pair

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -111,7 +111,7 @@ def one(
     return scan_config
 
 
-def result_set(
+def result_set(  # pylint: disable=too-many-locals
     result_set: str,  # pylint: disable=redefined-outer-name
     scan_requests: list[artifact.ScanRequest],
     only_producers: bool = False,
@@ -127,7 +127,9 @@ def result_set(
         existing_result_set_obj = store.result_set.load(result_set)
 
     result_set_obj = artifact.ResultSet(name=result_set)
-    for scan_request in scan_requests:
+    total = len(scan_requests)
+    for idx, scan_request in enumerate(scan_requests):
+        logging.info(f"capturing data for request {idx+1} of {total}")
         producer_data_path = None
         if scan_request.takes:
             producer = result_set_obj.provider(image=scan_request.image, provides=scan_request.takes)

--- a/src/yardstick/cli/cli.py
+++ b/src/yardstick/cli/cli.py
@@ -41,8 +41,6 @@ def cli(ctx, verbose: bool, config_path: str):
             "formatters": {
                 "standard": {
                     "()": DeltaTimeFormatter,
-                    # [%(module)s.%(funcName)s]
-                    # "format": "%(asctime)s [%(levelname)s] %(message)s",
                     "format": "%(delta)s [%(levelname)s] %(message)s",
                     "datefmt": "",
                 },

--- a/src/yardstick/cli/cli.py
+++ b/src/yardstick/cli/cli.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 import enum
 import logging
 from typing import Any
@@ -12,7 +13,7 @@ from yardstick.cli import config, label, result
 
 
 @click.option("--verbose", "-v", default=False, help="show logs", is_flag=True)
-@click.option("--config", "-c", "config_path", default=".yardstick.yaml", help="override config path")
+@click.option("--config", "-c", "config_path", default="", help="override config path")
 @click.group(help="Tool for parsing and comparing the vulnerability report output from multiple tools.")
 @click.pass_context
 def cli(ctx, verbose: bool, config_path: str):
@@ -28,13 +29,21 @@ def cli(ctx, verbose: bool, config_path: str):
     if verbose:
         log_level = "DEBUG"
 
+    class DeltaTimeFormatter(logging.Formatter):
+        def format(self, record):
+            duration = datetime.datetime.utcfromtimestamp(record.relativeCreated / 1000)
+            record.delta = duration.strftime("%H:%M:%S")
+            return super().format(record)
+
     logging.config.dictConfig(
         {
             "version": 1,
             "formatters": {
                 "standard": {
+                    "()": DeltaTimeFormatter,
                     # [%(module)s.%(funcName)s]
-                    "format": "%(asctime)s [%(levelname)s] %(message)s",
+                    # "format": "%(asctime)s [%(levelname)s] %(message)s",
+                    "format": "%(delta)s [%(levelname)s] %(message)s",
                     "datefmt": "",
                 },
             },

--- a/src/yardstick/cli/cli.py
+++ b/src/yardstick/cli/cli.py
@@ -40,8 +40,7 @@ def cli(ctx, verbose: bool, config_path: str):
             "version": 1,
             "formatters": {
                 "standard": {
-                    "()": DeltaTimeFormatter,
-                    "format": "%(delta)s [%(levelname)s] %(message)s",
+                    "format": "%(asctime)s [%(levelname)s] %(message)s",
                     "datefmt": "",
                 },
             },

--- a/src/yardstick/cli/cli.py
+++ b/src/yardstick/cli/cli.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 import enum
 import logging
 from typing import Any
@@ -28,12 +27,6 @@ def cli(ctx, verbose: bool, config_path: str):
     log_level = "INFO"
     if verbose:
         log_level = "DEBUG"
-
-    class DeltaTimeFormatter(logging.Formatter):
-        def format(self, record):
-            duration = datetime.datetime.utcfromtimestamp(record.relativeCreated / 1000)
-            record.delta = duration.strftime("%H:%M:%S")
-            return super().format(record)
 
     logging.config.dictConfig(
         {

--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -163,7 +163,4 @@ def _load(path: str) -> Application:
         if cfg is None:
             raise FileNotFoundError("parsed empty config")
 
-        # for _, result_set in cfg.result_sets.items():
-        #     result_set.matrix.__post_init__()
-
         return cfg

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -20,7 +20,7 @@ def group(_: config.Application):
     "compare",
     help="compare a scan result against labeled data",
 )
-@click.argument("result_ids", nargs=-1)
+@click.argument("descriptions", nargs=-1)
 @click.option(
     "--show-fns",
     default=False,
@@ -45,7 +45,7 @@ def group(_: config.Application):
 @click.pass_obj
 def compare_results_against_labels(
     cfg: config.Application,
-    result_ids: list[str],
+    descriptions: list[str],
     show_fns: bool,
     show_indeterminates: bool,
     fuzzy: bool,
@@ -57,7 +57,7 @@ def compare_results_against_labels(
         year_max_limit = cfg.default_max_year
 
     results, _, comparisons_by_result_id, stats_by_image_tool_pair = yardstick.compare_results_against_labels(
-        descriptions=result_ids,
+        descriptions=descriptions,
         result_set=result_set,
         fuzzy=fuzzy,
         year_max_limit=year_max_limit,

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -20,7 +20,7 @@ def group(_: config.Application):
     "compare",
     help="compare a scan result against labeled data",
 )
-@click.argument("descriptions", nargs=-1)
+@click.argument("result_ids", nargs=-1)
 @click.option(
     "--show-fns",
     default=False,
@@ -45,7 +45,7 @@ def group(_: config.Application):
 @click.pass_obj
 def compare_results_against_labels(
     cfg: config.Application,
-    descriptions: list[str],
+    result_ids: list[str],
     show_fns: bool,
     show_indeterminates: bool,
     fuzzy: bool,
@@ -57,7 +57,7 @@ def compare_results_against_labels(
         year_max_limit = cfg.default_max_year
 
     results, _, comparisons_by_result_id, stats_by_image_tool_pair = yardstick.compare_results_against_labels(
-        descriptions=descriptions,
+        descriptions=result_ids,
         result_set=result_set,
         fuzzy=fuzzy,
         year_max_limit=year_max_limit,
@@ -166,11 +166,11 @@ def remove_label(
 
 
 @group.command(name="explore", help="interact with an label results for a single image scan")
-@click.argument("description")
+@click.argument("result_id")
 @click.option("--year-max-limit", "-y", help="max year to include in comparison (relative to the CVE ID)")
 @click.option("--derive-year-from-cve-only", "-c", default=None, help="only use the CVE ID year-max-limit", is_flag=True)
 @click.pass_obj
-def explore_labels(cfg: config.Application, description: str, year_max_limit: int, derive_year_from_cve_only: bool | None):
+def explore_labels(cfg: config.Application, result_id: str, year_max_limit: int, derive_year_from_cve_only: bool | None):
     logging.disable(level=logging.CRITICAL)
 
     if not year_max_limit:
@@ -179,7 +179,7 @@ def explore_labels(cfg: config.Application, description: str, year_max_limit: in
     if derive_year_from_cve_only is None:
         derive_year_from_cve_only = cfg.derive_year_from_cve_only
 
-    scan_config = store.scan_result.find_one(by_description=description)
+    scan_config = store.scan_result.find_one(by_description=result_id)
     result = store.scan_result.load(
         config=scan_config, year_max_limit=year_max_limit, year_from_cve_only=derive_year_from_cve_only
     )
@@ -215,7 +215,7 @@ def show_image_lineage(_: config.Application, image: str):
 
 # pylint: disable=too-many-locals
 @group.command(name="apply", help="see which labels apply to the given image and tool pair")
-@click.argument("description")
+@click.argument("result_id")
 @click.option("--inverse", "-i", help="show image lables that should not be applied", is_flag=True)
 @click.option("--id", "show_ids", help="show IDs only", is_flag=True)
 @click.option("--year-max-limit", "-y", help="max year to include in comparison (relative to the CVE ID)")
@@ -223,7 +223,7 @@ def show_image_lineage(_: config.Application, image: str):
 @click.pass_obj
 def apply_labels(
     cfg: config.Application,
-    description: str,
+    result_id: str,
     inverse: bool,
     show_ids: bool,
     year_max_limit: int,
@@ -235,9 +235,9 @@ def apply_labels(
     if derive_year_from_cve_only is None:
         derive_year_from_cve_only = cfg.derive_year_from_cve_only
 
-    logging.info(f"applying labels to {description!r} (year limit: {year_max_limit})")
+    logging.info(f"applying labels to {result_id!r} (year limit: {year_max_limit})")
 
-    scan_config = store.scan_result.find_one(by_description=description)
+    scan_config = store.scan_result.find_one(by_description=result_id)
     result = store.scan_result.load(config=scan_config)
 
     lineage = store.image_lineage.get(scan_config.image)
@@ -286,7 +286,7 @@ def apply_labels(
         for _, l in found.items():
             show(l)
 
-    logging.info(f"found {len(found)} labels that apply to {description!r}")
+    logging.info(f"found {len(found)} labels that apply to {result_id!r}")
 
 
 @group.command(

--- a/src/yardstick/cli/result.py
+++ b/src/yardstick/cli/result.py
@@ -67,11 +67,11 @@ def capture_results(cfg: config.Application, image: str, tool: str, profile: str
     is_flag=True,
     help="show common match details",
 )
-@click.argument("descriptions", nargs=-1)
+@click.argument("ids", nargs=-1)
 @click.pass_obj
 def compare_results(
     cfg: config.Application,
-    descriptions: list[str],
+    ids: list[str],
     year_max_limit: int,
     # by: str,
     summary: bool,
@@ -80,7 +80,7 @@ def compare_results(
     if not year_max_limit:
         year_max_limit = cfg.default_max_year
 
-    comp = yardstick.compare_results(descriptions=descriptions, year_max_limit=year_max_limit)
+    comp = yardstick.compare_results(descriptions=ids, year_max_limit=year_max_limit)
 
     display.preserved_matches(comp, details=not summary, summary=summary, common=show_common)
 
@@ -125,11 +125,6 @@ def clear_results(_: config.Application):
 @click.option("--ids", "show_id", help="show result IDs only", is_flag=True)
 @click.pass_obj
 def list_results(cfg: config.Application, result_set: bool, show_id: bool, tools: list[str], images: list[str]):
-    if result_set:
-        result_set_config = cfg.result_sets.get(result_set, None)
-        if not result_set_config:
-            raise RuntimeError(f"no result set found for {result_set}")
-
     results = result_descriptions(result_set=result_set)
 
     if tools:
@@ -221,11 +216,41 @@ def result_descriptions(result_set: Optional[str] = None) -> list[ResultDescript
     return sorted(results)
 
 
-@group.command(name="sets", help="list configured result sets")
+@group.group(name="set", help="manipulate result sets")
+@click.pass_obj
+def set_group(cfg: config.Application):
+    pass
+
+@set_group.command(name="list", help="list configured result sets")
 @click.pass_obj
 def list_result_sets(cfg: config.Application):
-    for name in cfg.result_sets.keys():
-        print(f"{name:40} {cfg.result_sets[name].description}")
+    # if not cfg.result_sets:
+    #     print("no result sets configured")
+    #     return
+    # for name in cfg.result_sets.keys():
+    #     print(f"{name:40} {cfg.result_sets[name].description}")
+
+    for result_set in store.result_set.all():
+        print(result_set.name)
+
+
+@set_group.command(name="add", help="create a result set")
+@click.argument("ids", nargs=-1)
+@click.option("--name", "-n", "result_set", required=True, help="the name of the result set")
+@click.pass_obj
+def add_result_sets(cfg: config.Application, ids: list[str], result_set: str):
+    result_set_obj = artifact.ResultSet(name=result_set)
+    for scan_config_id in ids:
+        scan_config = store.scan_result.find_one(by_description=scan_config_id)
+        scan_request = artifact.ScanRequest(image=scan_config.full_image, tool=scan_config.tool)
+
+        if not scan_config:
+            raise RuntimeError(f"unable to find scan configuration for {scan_request}")
+
+        result_set_obj.add(request=scan_request, scan_config=scan_config)
+    store.result_set.save(result_set_obj)
+
+
 
 
 @group.command(name="import", help="import results for a tool that were run externally")
@@ -247,21 +272,22 @@ def import_results(_: config.Application, image: str, tool: str, file: str = Non
 
     match_results = capture.intake(config=scan_config, raw_results=raw_results)
     store.scan_result.save(raw_results, match_results)
+    print(scan_config.ID)
 
 
 @group.command(name="explore", help="interact with an image scan result")
-@click.argument("description")
+@click.argument("ids")
 @click.option("--year-max-limit", "-y", help="max year to include in comparison (relative to the CVE ID)")
 @click.option("--derive-year-from-cve-only", "-c", default=None, help="only use the CVE ID year-max-limit", is_flag=True)
 @click.pass_obj
-def explore_results(cfg: config.Application, description: str, year_max_limit: int, derive_year_from_cve_only: None | bool):
+def explore_results(cfg: config.Application, ids: str, year_max_limit: int, derive_year_from_cve_only: None | bool):
     if not year_max_limit:
         year_max_limit = cfg.default_max_year
 
     if derive_year_from_cve_only is None:
         derive_year_from_cve_only = cfg.derive_year_from_cve_only
 
-    scan_config = store.scan_result.find_one(by_description=description)
+    scan_config = store.scan_result.find_one(by_description=ids)
     result = store.scan_result.load(config=scan_config)
     if year_max_limit:
         results = store.scan_result.filter_by_year([result], int(year_max_limit), year_from_cve_only=derive_year_from_cve_only)

--- a/src/yardstick/cli/result.py
+++ b/src/yardstick/cli/result.py
@@ -124,7 +124,7 @@ def clear_results(_: config.Application):
 @click.option("--images", "-i", "images", help="filter results down to that partially match given image names", multiple=True)
 @click.option("--ids", "show_id", help="show result IDs only", is_flag=True)
 @click.pass_obj
-def list_results(cfg: config.Application, result_set: bool, show_id: bool, tools: list[str], images: list[str]):
+def list_results(_: config.Application, result_set: bool, show_id: bool, tools: list[str], images: list[str]):
     results = result_descriptions(result_set=result_set)
 
     if tools:
@@ -218,19 +218,14 @@ def result_descriptions(result_set: Optional[str] = None) -> list[ResultDescript
 
 @group.group(name="set", help="manipulate result sets")
 @click.pass_obj
-def set_group(cfg: config.Application):
+def set_group(_: config.Application):
     pass
+
 
 @set_group.command(name="list", help="list configured result sets")
 @click.pass_obj
-def list_result_sets(cfg: config.Application):
-    # if not cfg.result_sets:
-    #     print("no result sets configured")
-    #     return
-    # for name in cfg.result_sets.keys():
-    #     print(f"{name:40} {cfg.result_sets[name].description}")
-
-    for result_set in store.result_set.all():
+def list_result_sets(_: config.Application):
+    for result_set in store.result_set.load_all():
         print(result_set.name)
 
 
@@ -238,7 +233,7 @@ def list_result_sets(cfg: config.Application):
 @click.argument("ids", nargs=-1)
 @click.option("--name", "-n", "result_set", required=True, help="the name of the result set")
 @click.pass_obj
-def add_result_sets(cfg: config.Application, ids: list[str], result_set: str):
+def add_result_sets(_: config.Application, ids: list[str], result_set: str):
     result_set_obj = artifact.ResultSet(name=result_set)
     for scan_config_id in ids:
         scan_config = store.scan_result.find_one(by_description=scan_config_id)
@@ -249,8 +244,6 @@ def add_result_sets(cfg: config.Application, ids: list[str], result_set: str):
 
         result_set_obj.add(request=scan_request, scan_config=scan_config)
     store.result_set.save(result_set_obj)
-
-
 
 
 @group.command(name="import", help="import results for a tool that were run externally")

--- a/src/yardstick/store/__init__.py
+++ b/src/yardstick/store/__init__.py
@@ -1,1 +1,1 @@
-from . import config, image_lineage, labels, naming, result_set, scan_result, tool
+from . import config, image_lineage, label_stats, labels, naming, result_set, scan_result, tool

--- a/src/yardstick/store/image_lineage.py
+++ b/src/yardstick/store/image_lineage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from dataclasses import dataclass
@@ -17,14 +19,14 @@ class ImageLineageDocument:
     lineage: Dict[str, List[str]]
 
 
-def store_path(suffix: str = SUFFIX, store_root: str = None) -> str:
+def store_path(suffix: str = SUFFIX, store_root: str | None = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
 
     return os.path.join(store_root, IMAGE_LINEAGE_DIR, "image-lineage" + suffix)
 
 
-def add(image: str, lineage: List[str], store_root: str = None):
+def add(image: str, lineage: List[str], store_root: str | None = None):
     data_path = store_path(store_root=store_root)
     logging.debug(f"storing image lineage to {data_path!r}")
 
@@ -37,11 +39,11 @@ def add(image: str, lineage: List[str], store_root: str = None):
         data_file.write(ImageLineageDocument(lineage=existing).to_json(indent=2))  # pylint: disable=no-member
 
 
-def get_parents(image: str, store_root: str = None) -> List[str]:
+def get_parents(image: str, store_root: str | None = None) -> List[str]:
     return load(store_root).get(image, [])
 
 
-def get(image: str, store_root: str = None) -> List[str]:
+def get(image: str, store_root: str | None = None) -> List[str]:
     result = []
     parents = get_parents(image, store_root=store_root)
     result += parents
@@ -53,7 +55,7 @@ def get(image: str, store_root: str = None) -> List[str]:
     return result
 
 
-def load(store_root: str = None) -> Dict[str, List[str]]:
+def load(store_root: str | None = None) -> Dict[str, List[str]]:
     data_path = store_path(store_root=store_root)
     logging.debug(f"loading image lineage location={data_path!r}")
 

--- a/src/yardstick/store/label_stats.py
+++ b/src/yardstick/store/label_stats.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+from typing import Any, List
+
+from yardstick import comparison
+from yardstick.store import config as store_config
+
+LABEL_STATS_DIR = "label-stats"
+
+
+def _store_root(store_root: str | None = None) -> str:
+    if not store_root:
+        store_root = store_config.get().store_root
+    return os.path.join(store_root, LABEL_STATS_DIR)
+
+
+def store_path(ids: List[str], configuration: list[dict[str, Any]] | None, store_root: str | None = None) -> str:
+    config_str = _derive_configuration_string(configuration)
+
+    filename = "_".join(sorted(ids)) + "_" + config_str + ".json"
+
+    return os.path.join(_store_root(store_root=store_root), filename)
+
+
+def clear(store_root: str | None = None):
+    try:
+        shutil.rmtree(_store_root(store_root=store_root))
+    except FileNotFoundError:
+        pass
+
+
+def save(result: comparison.ImageToolLabelStats, store_root: str | None = None):
+    if not isinstance(result, comparison.ImageToolLabelStats):
+        raise RuntimeError(f"only ImageToolLabelStats is supported, given {type(result)}")
+
+    ids = [c.ID for c in result.configs]
+    path = store_path(ids, result.compare_configs, store_root=store_root)
+    logging.debug(f"storing label comparison state for {ids!r}")
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as data_file:
+        data_file.write(json.dumps(result.to_dict(), indent=2))
+
+
+def _derive_configuration_string(configurations: list[dict[str, str]] | None) -> str:
+    if configurations is None:
+        return "no-configuration"
+
+    config_strs = []
+    for configuration in configurations:
+        config_str = ",".join([f"{k}={v}" for k, v in sorted(configuration.items())])
+        config_strs.append(config_str)
+
+    return hashlib.sha256(",".join(config_strs).encode("utf-8")).hexdigest()
+
+
+def load(
+    ids: List[str], configurations: list[dict[str, Any]] | None = None, store_root: str | None = None
+) -> comparison.ImageToolLabelStats:
+    data_path = store_path(ids, configurations, store_root=store_root)
+
+    logging.debug(f"loading label comparison state for {ids!r} with detailed configurations location={data_path!r}")
+
+    with open(data_path, "r", encoding="utf-8") as data_file:
+        data_json = data_file.read()
+
+    return comparison.ImageToolLabelStats.from_json(data_json)  # pylint: disable=no-member

--- a/src/yardstick/store/label_stats.py
+++ b/src/yardstick/store/label_stats.py
@@ -20,7 +20,7 @@ def _store_root(store_root: str | None = None) -> str:
 
 
 def store_path(ids: List[str], configuration: list[dict[str, Any]] | None, store_root: str | None = None) -> str:
-    config_str = _derive_configuration_string(configuration)
+    config_str = _configuration_string(configuration)
 
     filename = "_".join(sorted(ids)) + "_" + config_str + ".json"
 
@@ -48,7 +48,7 @@ def save(result: comparison.ImageToolLabelStats, store_root: str | None = None):
         data_file.write(json.dumps(result.to_dict(), indent=2))
 
 
-def _derive_configuration_string(configurations: list[dict[str, str]] | None) -> str:
+def _configuration_string(configurations: list[dict[str, str]] | None) -> str:
     if configurations is None:
         return "no-configuration"
 

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import glob
 import json
@@ -15,7 +17,7 @@ from yardstick.utils import remove_prefix
 LABELS_DIR = "labels"
 
 
-def label_store_root(store_root: str = None) -> str:
+def label_store_root(store_root: str | None = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
     return os.path.join(store_root, LABELS_DIR)
@@ -31,12 +33,12 @@ def store_filename_by_entry(entry: artifact.LabelEntry) -> str:
     return f"{entry.source}.json"
 
 
-def store_path(filename: str, store_root: str = None) -> str:
+def store_path(filename: str, store_root: str | None = None) -> str:
     return os.path.join(label_store_root(store_root=store_root), filename)
 
 
 def append_and_update(
-    new_and_modified_entries: List[artifact.LabelEntry], delete_entries: List[str] = None, store_root: str = None
+    new_and_modified_entries: List[artifact.LabelEntry], delete_entries: List[str] | None = None, store_root: str | None = None
 ) -> List[artifact.LabelEntry]:
     for label_entry in delete_entries:
         filepath = store_path(filename=store_filename_by_entry(entry=label_entry))
@@ -86,7 +88,7 @@ def overwrite_all(label_entries: List[artifact.LabelEntry], store_root: str = No
 
 
 def load_label_file(
-    filename: str, year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    filename: str, year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str | None = None
 ) -> List[artifact.LabelEntry]:
     # why note take a file path? in this way we control that all input/output data was derived from the same store,
     # and not another store.
@@ -115,7 +117,7 @@ def load_label_file(
 
 
 def load_all(
-    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str | None = None
 ) -> List[artifact.LabelEntry]:
     root_path = label_store_root(store_root=store_root)
     logging.debug(f"loading all labels (location={root_path})")
@@ -137,7 +139,10 @@ def load_all(
 
 
 def load_for_image(
-    images: Union[str, List[str]], year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    images: Union[str, List[str]],
+    year_max_limit: Optional[int] = None,
+    year_from_cve_only: bool = False,
+    store_root: str | None = None,
 ) -> List[artifact.LabelEntry]:
     root_path = label_store_root(store_root=store_root)
     if isinstance(images, str):

--- a/src/yardstick/store/result_set.py
+++ b/src/yardstick/store/result_set.py
@@ -73,3 +73,13 @@ def load_scan_results(
 def exists(name: str, store_root: str | None = None) -> bool:
     data_path = store_paths(name, store_root=store_root)
     return os.path.exists(data_path)
+
+def all(store_root: str | None = None) -> list[artifact.ResultSet]:
+    parent_dir = _store_root(store_root=store_root)
+    result_sets = []
+
+    for file_name in os.listdir(parent_dir):
+        if file_name.endswith(".json"):
+            result_sets.append(load(file_name[:-5], store_root=store_root))
+
+    return result_sets

--- a/src/yardstick/store/result_set.py
+++ b/src/yardstick/store/result_set.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -9,27 +11,27 @@ from yardstick.store import config as store_config
 from yardstick.store import scan_result, tool
 
 
-def _store_root(store_root: str = None):
+def _store_root(store_root: str | None = None):
     if not store_root:
         store_root = store_config.get().store_root
 
     return tool.result_set_path(store_root=store_root)
 
 
-def clear(store_root: str = None):
+def clear(store_root: str | None = None):
     try:
         shutil.rmtree(_store_root(store_root=store_root))
     except FileNotFoundError:
         pass
 
 
-def store_paths(name: str, store_root: str = None) -> str:
+def store_paths(name: str, store_root: str | None = None) -> str:
     parent_dir = _store_root(store_root=store_root)
 
     return os.path.join(parent_dir, f"{name}.json")
 
 
-def save(results: artifact.ResultSet, store_root: str = None):
+def save(results: artifact.ResultSet, store_root: str | None = None):
     if not isinstance(results, artifact.ResultSet):
         raise RuntimeError(f"only ResultSet is supported, given {type(results)}")
 
@@ -42,7 +44,7 @@ def save(results: artifact.ResultSet, store_root: str = None):
         data_file.write(json.dumps(results.to_dict(), indent=2))
 
 
-def load(name: str, store_root: str = None) -> artifact.ResultSet:
+def load(name: str, store_root: str | None = None) -> artifact.ResultSet:
     data_path = store_paths(name, store_root=store_root)
     logging.debug(f"loading result set {name!r} location={data_path!r}")
 
@@ -53,7 +55,7 @@ def load(name: str, store_root: str = None) -> artifact.ResultSet:
 
 
 def load_scan_results(
-    name: str, year_max_limit: Optional[int] = None, store_root: str = None, skip_sbom_results: bool = False
+    name: str, year_max_limit: Optional[int] = None, store_root: str | None = None, skip_sbom_results: bool = False
 ) -> list[artifact.ScanResult]:
     data_path = store_paths(name, store_root=store_root)
     logging.debug(f"loading scan results from result set {name!r} location={data_path!r}")
@@ -68,6 +70,6 @@ def load_scan_results(
     return results
 
 
-def exists(name: str, store_root: str = None) -> bool:
+def exists(name: str, store_root: str | None = None) -> bool:
     data_path = store_paths(name, store_root=store_root)
     return os.path.exists(data_path)

--- a/src/yardstick/store/result_set.py
+++ b/src/yardstick/store/result_set.py
@@ -74,7 +74,8 @@ def exists(name: str, store_root: str | None = None) -> bool:
     data_path = store_paths(name, store_root=store_root)
     return os.path.exists(data_path)
 
-def all(store_root: str | None = None) -> list[artifact.ResultSet]:
+
+def load_all(store_root: str | None = None) -> list[artifact.ResultSet]:
     parent_dir = _store_root(store_root=store_root)
     result_sets = []
 

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import glob
 import itertools
@@ -14,21 +16,23 @@ from yardstick.store import naming, tool
 from yardstick.tool import sbom_generator, tools, vulnerability_scanner
 
 
-def _store_root(store_root: str = None):
+def _store_root(store_root: str | None = None):
     if not store_root:
         store_root = store_config.get().store_root
 
     return tool.results_path(store_root=store_root)
 
 
-def clear(store_root: str = None):
+def clear(store_root: str | None = None):
     try:
         shutil.rmtree(_store_root(store_root=store_root))
     except FileNotFoundError:
         pass
 
 
-def store_paths(config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX, store_root: str = None) -> Tuple[str, str]:
+def store_paths(
+    config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX, store_root: str | None = None
+) -> Tuple[str, str]:
     # repo@digest/tool@version/timestamp/data.json
     # repo@digest/tool@version/timestamp/metadata.json
 
@@ -44,7 +48,7 @@ def store_paths(config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX,
 
 
 # note: we intentionally split up the data and metadata such that matches are recomputed with the latest code changes
-def save(raw: str, results: artifact.ScanResult, store_root: str = None):
+def save(raw: str, results: artifact.ScanResult, store_root: str | None = None):
     if not isinstance(results, artifact.ScanResult):
         raise RuntimeError(f"only ScanResult is supported, given {type(results)}")
 
@@ -155,7 +159,7 @@ def load_by_descriptions(
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
     skip_sbom_results: bool = False,
-    store_root: str = None,
+    store_root: str | None = None,
 ) -> list[artifact.ScanResult]:
     results = []
     for description in descriptions:
@@ -173,7 +177,7 @@ def load_all(
     configs: list[artifact.ScanConfiguration],
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
-    store_root: str = None,
+    store_root: str | None = None,
 ) -> list[artifact.ScanResult]:
     return [
         load(config, year_max_limit=year_max_limit, year_from_cve_only=year_from_cve_only, store_root=store_root)
@@ -186,7 +190,7 @@ def load(
     config: artifact.ScanConfiguration,
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
-    store_root: str = None,
+    store_root: str | None = None,
 ) -> artifact.ScanResult:
     data_path, metadata_path = store_paths(config, store_root=store_root)
     logging.debug(f"loading result config={config!r} location={data_path!r}")
@@ -229,12 +233,12 @@ def load(
     return result_obj
 
 
-def list_all_metadata_json(store_root: str = None):
+def list_all_metadata_json(store_root: str | None = None):
     json_path = tool.results_path(store_root=store_root)
     return glob.glob(f"{json_path}/*/*/*/metadata.json")
 
 
-def list_all_configs(store_root: str = None) -> List[artifact.ScanConfiguration]:
+def list_all_configs(store_root: str | None = None) -> List[artifact.ScanConfiguration]:
     results = []
     for metadata_file in list_all_metadata_json(store_root=store_root):
         with open(metadata_file, "r", encoding="utf-8") as metadata_file:

--- a/src/yardstick/store/tool.py
+++ b/src/yardstick/store/tool.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from yardstick import artifact
@@ -8,7 +10,7 @@ RESULT_DIR = os.path.join("result", "store")
 RESULT_SET_DIR = os.path.join("result", "sets")
 
 
-def install_path(config: artifact.ScanConfiguration, store_root: str = None) -> str:
+def install_path(config: artifact.ScanConfiguration, store_root: str | None = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
 
@@ -20,14 +22,14 @@ def install_path(config: artifact.ScanConfiguration, store_root: str = None) -> 
     )
 
 
-def results_path(store_root: str = None):
+def results_path(store_root: str | None = None):
     if not store_root:
         store_root = store_config.get().store_root
 
     return os.path.join(store_root, RESULT_DIR)
 
 
-def result_set_path(store_root: str = None):
+def result_set_path(store_root: str | None = None):
     if not store_root:
         store_root = store_config.get().store_root
 


### PR DESCRIPTION
This enables API users to optionally store the `comparison.ImageToolLabelStats` dataclass to disk, enabling reuse of the raw stats for analysis without needing to recompute from the raw data.

This additionally: 
- adds the configuration loading behavior to allow for `yardstick.yaml` files (we will still look for `.yardstick.yaml` files first).
- addresses some type hint inconsistencies.
