### PR TITLE
fix: `yardstick label remove $LABEL_ID` removes the label

### DIFF
--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -7,7 +7,7 @@ import click
 import yardstick
 from yardstick import artifact, label, store
 from yardstick.cli import config, display, explore
-from yardstick.store.labels import delete_entries
+from yardstick.store.labels import delete_labels_by_id
 
 
 @click.group(name="label", help="manage match labels")
@@ -158,7 +158,7 @@ def remove_label(
     _: config.Application,
     label_ids: list[str],
 ):
-    deleted_ids = delete_entries(label_ids)
+    deleted_ids = delete_labels_by_id(label_ids)
     for d in deleted_ids:
         print(d)
     logging.info(f"removed {len(deleted_ids)} labels")

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -7,7 +7,6 @@ import click
 import yardstick
 from yardstick import artifact, label, store
 from yardstick.cli import config, display, explore
-from yardstick.store.labels import delete_labels_by_id
 
 
 @click.group(name="label", help="manage match labels")
@@ -147,7 +146,7 @@ def add_label(
         note=note,
         lookup_effective_cve=True,
     )
-    store.labels.save_label_entries([new_label])
+    store.labels.save([new_label])
     print(new_label.ID)
 
 
@@ -158,7 +157,7 @@ def remove_label(
     _: config.Application,
     label_ids: list[str],
 ):
-    deleted_ids = delete_labels_by_id(label_ids)
+    deleted_ids = store.labels.delete(label_ids)
     for d in deleted_ids:
         print(d)
     logging.info(f"removed {len(deleted_ids)} labels")

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -159,10 +159,10 @@ def remove_label(
     label_ids: list[str],
 ):
     label_entries = store.labels.load_all()
-    old_len = len(label_entries)
-    label_entries = [l for l in label_entries if l.ID not in label_ids]
-    store.labels.overwrite_all(label_entries)
-    logging.info(f"removed {old_len-len(label_entries)} labels")
+    to_delete = [l for l in label_entries if l.ID in label_ids]
+    to_keep = [l for l in label_entries if l.ID not in label_ids]
+    store.labels.append_and_update(to_keep, delete_entries=to_delete)
+    logging.info(f"removed {len(label_entries) - len(to_keep)} labels")
 
 
 @group.command(name="explore", help="interact with an label results for a single image scan")

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -45,10 +45,10 @@ def append_and_update(
             logging.error(f"failed to delete label {label_entry.ID} from {filepath}: {e}")
             raise e
 
-    save_label_entries(label_entries=new_and_modified_entries, store_root=store_root)
+    save(label_entries=new_and_modified_entries, store_root=store_root)
 
 
-def delete_labels_by_id(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
+def delete(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
     """delete_entries takes a list of ids to be deleted and returns a list of deleted files.
     FileNotFound exceptions are ignored."""
     label_store_dir = label_store_root(store_root=store_root)
@@ -67,7 +67,7 @@ def delete_labels_by_id(label_ids_to_delete: List[str], store_root: str = None) 
     return deleted_ids
 
 
-def save_label_entries(label_entries: List[artifact.LabelEntry], store_root: str = None):
+def save(label_entries: List[artifact.LabelEntry], store_root: str = None):
     root_path = label_store_root(store_root=store_root)
     logging.debug(f"storing all labels location={root_path}")
 

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Union
 
 import omitempty
 
-from yardstick import artifact, label
+from yardstick import artifact
 from yardstick.store import config as store_config
 from yardstick.store import naming
 from yardstick.utils import remove_prefix
@@ -47,7 +47,8 @@ def append_and_update(
 
     save_label_entries(label_entries=new_and_modified_entries, store_root=store_root)
 
-def delete_entries(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
+
+def delete_labels_by_id(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
     """delete_entries takes a list of ids to be deleted and returns a list of deleted files.
     FileNotFound exceptions are ignored."""
     label_store_dir = label_store_root(store_root=store_root)
@@ -64,6 +65,7 @@ def delete_entries(label_ids_to_delete: List[str], store_root: str = None) -> Li
                 logging.error(f"failed to delete label {label_id} from {p}: {e}")
                 raise e
     return deleted_ids
+
 
 def save_label_entries(label_entries: List[artifact.LabelEntry], store_root: str = None):
     root_path = label_store_root(store_root=store_root)

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -36,14 +36,18 @@ def store_path(filename: str, store_root: str = None) -> str:
 
 
 def append_and_update(
-    new_and_modified_entries: List[artifact.LabelEntry], delete_entries: List[str] = None, store_root: str = None
+    new_and_modified_entries: List[artifact.LabelEntry], delete_entries: List[artifact.LabelEntry] = None, store_root: str = None
 ) -> List[artifact.LabelEntry]:
     for label_entry in delete_entries:
         filepath = store_path(filename=store_filename_by_entry(entry=label_entry))
         try:
+            logging.debug(f"deleting label {label_entry.ID} from {filepath}")
             os.remove(filepath)
-        except:  # pylint: disable=bare-except
-            pass
+        except FileNotFoundError:
+            logging.debug(f"skipping deleting on {label_entry.ID} from {filepath}: File not found")
+        except Exception as e:  # pylint: disable=broad-except
+            logging.error(f"failed to delete label {label_entry.ID} from {filepath}: {e}")
+            raise e
 
     overwrite_all(label_entries=new_and_modified_entries, store_root=store_root)
 

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -77,10 +77,12 @@ run yardstick label apply $(yardstick result list -r test --ids -t grype@v0.50.2
 assert_last_output_contains "label: TruePositive"
 
 ID_TO_REMOVE="$(yardstick label list | grep id: | cut -d ' ' -f 2 | head -n 1)"
-BAK_FILE="$(yardstick label list | grep id: | cut -d ' ' -f 2 | head -n 1).bak"
+LABEL_FILE=".yardstick/labels/docker.io+anchore+test_images@sha256:10008791acbc5866de04108746a02a0c4029ce3a4400a9b3dad45d7f2245f9da/${ID_TO_REMOVE}.json"
+BAK_FILE="${LABEL_FILE}.bak"
+cp ${LABEL_FILE} ${BAK_FILE}
 run yardstick label remove ${ID_TO_REMOVE}
-run find . -name "${ID_TO_REMOVE}.json"
-assert_last_output_length 0
+test -f ${LABEL_FILE} && echo -e "${ERROR}Label file not removed${RESET}" && exit 1
+cp ${BAK_FILE} ${LABEL_FILE} && rm ${BAK_FILE}
 
 echo "cleaning up temp files created:"
 for i in ${!temp_files[@]}; do

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -76,13 +76,9 @@ run yardstick label apply $(yardstick result list -r test --ids -t grype@v0.50.2
 
 assert_last_output_contains "label: TruePositive"
 
-ID_TO_REMOVE="$(yardstick label list | grep id: | cut -d ' ' -f 2 | head -n 1)"
-LABEL_FILE=".yardstick/labels/docker.io+anchore+test_images@sha256:10008791acbc5866de04108746a02a0c4029ce3a4400a9b3dad45d7f2245f9da/${ID_TO_REMOVE}.json"
-BAK_FILE="${LABEL_FILE}.bak"
-cp ${LABEL_FILE} ${BAK_FILE}
+ID_TO_REMOVE=$(yardstick label add -i foo -c CVE-1234-ASDF -p test-package -v 1.2.3 -n "testing" --label TP)
 run yardstick label remove ${ID_TO_REMOVE}
-test -f ${LABEL_FILE} && echo -e "${ERROR}Label file not removed${RESET}" && exit 1
-cp ${BAK_FILE} ${LABEL_FILE} && rm ${BAK_FILE}
+assert_last_output_contains ${ID_TO_REMOVE}
 
 echo "cleaning up temp files created:"
 for i in ${!temp_files[@]}; do

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -76,6 +76,12 @@ run yardstick label apply $(yardstick result list -r test --ids -t grype@v0.50.2
 
 assert_last_output_contains "label: TruePositive"
 
+ID_TO_REMOVE="$(yardstick label list | grep id: | cut -d ' ' -f 2 | head -n 1)"
+BAK_FILE="$(yardstick label list | grep id: | cut -d ' ' -f 2 | head -n 1).bak"
+run yardstick label remove ${ID_TO_REMOVE}
+run find . -name "${ID_TO_REMOVE}.json"
+assert_last_output_length 0
+
 echo "cleaning up temp files created:"
 for i in ${!temp_files[@]}; do
   echo "   " ${temp_files[$i]}


### PR DESCRIPTION
Previously, `yardstick label remove` didn't remove the label. Make it remove the label, and add a CLI test for this behavior.

Fixes #105.