### PR TITLE
feat: install grype from path

### DIFF
--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -169,8 +169,8 @@ class Grype(VulnerabilityScanner):
         if repo.is_dirty():
             hash_obj = hashlib.sha1()
             for untracked in repo.untracked_files:
-                with open(os.path.join(repo.working_dir, untracked), "rb") as f:
-                    for chunk in iter(lambda: f.read(4096), b""):
+                with open(os.path.join(repo.working_dir, untracked), "rb") as untracked_file:
+                    for chunk in iter(lambda: untracked_file.read(4096), b""):  # pylint: disable=cell-var-from-loop
                         hash_obj.update(chunk)
             hash_obj.update(repo.git.diff("--stat", "HEAD").encode())
             diff_digest = hash_obj.hexdigest()[:8]

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -1,6 +1,6 @@
 import atexit
-import json
 import hashlib
+import json
 import logging
 import os
 import re

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -198,7 +198,7 @@ class Grype(VulnerabilityScanner):
 
     @staticmethod
     def _run_go_build(
-        abs_install_dir: str,  # TODO: rename; what is an absolute path to?
+        abs_install_dir: str,
         repo_path: str,
         description: str,
         binpath: str,

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -173,7 +173,7 @@ class Grype(VulnerabilityScanner):
         # get the description and head ref from the repo
 
         description = repo.git.describe("--tags", "--always", "--long")
-        dest_path = os.path.join(path, "git_install", description)
+        dest_path = os.path.join(path, "local_install", description)
         os.makedirs(dest_path, exist_ok=True)
         cls._run_go_build(
             abspath=os.path.abspath(dest_path),
@@ -276,10 +276,29 @@ class Grype(VulnerabilityScanner):
             version,
         ):
             tool_obj = cls._install_from_installer(
-                version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs
+                version=version,
+                path=path,
+                use_cache=use_cache,
+                profile=grype_profile,
+                **kwargs,
+            )
+        elif version.startswith("path:"):
+            tool_obj = cls._install_from_path(
+                path=path.replace("path:", ""),
+                src_path=version.removeprefix("path:"),
+                version=version.removeprefix("path:"),
+                use_cache=use_cache,
+                profile=grype_profile,
+                **kwargs,
             )
         else:
-            tool_obj = cls._install_from_git(version=version, path=path, use_cache=use_cache, profile=grype_profile, **kwargs)
+            tool_obj = cls._install_from_git(
+                version=version,
+                path=path,
+                use_cache=use_cache,
+                profile=grype_profile,
+                **kwargs,
+            )
 
         # always update the DB, raise exception on failure
         if db_import_path:

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -145,7 +145,7 @@ class Grype(VulnerabilityScanner):
         abspath = os.path.abspath(path)
         if not tool_exists:
             cls._run_go_build(
-                abspath=abspath,
+                abs_install_dir=abspath,
                 repo_path=repo_path,
                 description=description,
                 binpath=path,
@@ -188,7 +188,7 @@ class Grype(VulnerabilityScanner):
         dest_path = os.path.join(path.replace("path:", ""), build_version, "local_install")
         os.makedirs(dest_path, exist_ok=True)
         cls._run_go_build(
-            abspath=os.path.abspath(dest_path),
+            abs_install_dir=os.path.abspath(dest_path),
             description=f"{path}:{build_version}",
             repo_path=src_repo_path,
             binpath=dest_path,
@@ -198,23 +198,23 @@ class Grype(VulnerabilityScanner):
 
     @staticmethod
     def _run_go_build(
-        abspath: str,  # TODO: rename; what is an absolute path to?
+        abs_install_dir: str,  # TODO: rename; what is an absolute path to?
         repo_path: str,
         description: str,
         binpath: str,
         version_ref: str = "github.com/anchore/grype/internal/version.version",
     ):
-        logging.debug(f"installing grype via build to {abspath!r}")
+        logging.debug(f"installing grype via build to {abs_install_dir!r}")
 
         main_pkg_path = "./cmd/grype"
         if not os.path.exists(os.path.join(repo_path, "cmd", "grype", "main.go")):
             # support legacy installations, when the main.go was in the root of the repo
             main_pkg_path = "."
 
-        c = f"go build -ldflags \"-w -s -extldflags '-static' -X {version_ref}={description}\" -o {abspath} {main_pkg_path}"
+        c = f"go build -ldflags \"-w -s -extldflags '-static' -X {version_ref}={description}\" -o {abs_install_dir} {main_pkg_path}"
         logging.debug(f"running {c!r}")
 
-        e = {"GOBIN": abspath, "CGO_ENABLED": "0"}
+        e = {"GOBIN": abs_install_dir, "CGO_ENABLED": "0"}
         e.update(os.environ)
 
         subprocess.check_call(

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -166,7 +166,8 @@ class Grype(VulnerabilityScanner):
             logging.error(f"failed to open existing grype repo at {src_path!r}")
             raise
         git_desc = repo.git.describe("--tags", "--always", "--long", "--dirty")
-        diff_digest = hashlib.sha1(repo.git.diff("--stat", "HEAD").encode()).hexdigest()
+        if repo.is_dirty():
+            diff_digest = hashlib.sha1(repo.git.diff("--stat", "HEAD").encode()).hexdigest()
         return f"{git_desc}-{diff_digest}"
 
     @classmethod

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -154,6 +154,23 @@ class Grype(VulnerabilityScanner):
 
         return Grype(path=path, version_detail=description, **kwargs)
 
+    @classmethod
+    def _install_from_path(
+        cls,
+        path: str,
+        use_cache: Optional[bool] = True,
+        **kwargs,
+    ) -> "Grype":
+        logging.debug(f"installing grype from path={path!r}")
+        buildpath = os.path.abspath(path)
+        if not os.path.exists(buildpath):
+            raise ValueError(f"invalid path={path!r}")
+        repo_path = os.path.join(buildpath, "source")
+        if not os.path.exists(repo_path):
+            os.makedirs(repo_path)
+
+
+        return Grype(path=path, **kwargs)
     @staticmethod
     def _run_go_build(
         abspath: str,

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -31,9 +31,15 @@ def test_install_from_path():
         exists.return_value = True
         fake_repo = mock.Mock()
         fake_repo.git = mock.Mock()
-        fake_repo.git.describe.return_value = "test-version"
+        git_describe_val = "v0.65.1-1-g74a7a67-dirty"
+        hash_of_git_diff = "a29864cf5600b481056b6fa30a21cdbabc15287d"
+        fake_repo.git.describe.return_value = git_describe_val
+        fake_repo.git.diff.return_value = "test-diff" # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
         repo.return_value = fake_repo
+        version_str = "path:/where/grype/is/cloned"
+        normalized_version_str = version_str.replace("/", "_").removeprefix("path:")
+        expected_grype_path = f".yardstick/tools/grype/{normalized_version_str}/{git_describe_val}-{hash_of_git_diff}/local_install"
         tool = Grype.install(
-            version="path:/where/grype/is/cloned", path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False
+            version=version_str, path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False
         )
-        assert tool.path == ".yardstick/tools/grype/_where_grype_is_cloned/local_install"
+        assert tool.path == expected_grype_path

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -21,3 +21,18 @@ def test_grype_no_profile():
         tool = Grype(path="test-path")
         tool.capture(image="test-image", tool_input=None)
         assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image"]
+
+def test_install_from_path():
+    with mock.patch("subprocess.check_call") as check_call, \
+        mock.patch("git.Repo") as repo, \
+        mock.patch("os.path.exists") as exists, \
+        mock.patch("os.makedirs") as makedirs, \
+        mock.patch("os.chmod") as chmod:
+        check_call.return_value = bytes("test-output", "utf-8")
+        exists.return_value = True
+        fake_repo = mock.Mock()
+        fake_repo.git = mock.Mock()
+        fake_repo.git.describe.return_value = "test-version"
+        repo.return_value = fake_repo
+        tool = Grype.install(version="path:/where/grype/is/cloned", path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False)
+        assert tool.path == ".yardstick/tools/grype/_where_grype_is_cloned/local_install"

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -22,17 +22,18 @@ def test_grype_no_profile():
         tool.capture(image="test-image", tool_input=None)
         assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image"]
 
+
 def test_install_from_path():
-    with mock.patch("subprocess.check_call") as check_call, \
-        mock.patch("git.Repo") as repo, \
-        mock.patch("os.path.exists") as exists, \
-        mock.patch("os.makedirs") as makedirs, \
-        mock.patch("os.chmod") as chmod:
+    with mock.patch("subprocess.check_call") as check_call, mock.patch("git.Repo") as repo, mock.patch(
+        "os.path.exists"
+    ) as exists, mock.patch("os.makedirs") as makedirs, mock.patch("os.chmod") as chmod:
         check_call.return_value = bytes("test-output", "utf-8")
         exists.return_value = True
         fake_repo = mock.Mock()
         fake_repo.git = mock.Mock()
         fake_repo.git.describe.return_value = "test-version"
         repo.return_value = fake_repo
-        tool = Grype.install(version="path:/where/grype/is/cloned", path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False)
+        tool = Grype.install(
+            version="path:/where/grype/is/cloned", path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False
+        )
         assert tool.path == ".yardstick/tools/grype/_where_grype_is_cloned/local_install"

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -31,8 +31,9 @@ def test_install_from_path():
         exists.return_value = True
         fake_repo = mock.Mock()
         fake_repo.git = mock.Mock()
+        fake_repo.untracked_files = []
         git_describe_val = "v0.65.1-1-g74a7a67-dirty"
-        hash_of_git_diff = "a29864cf5600b481056b6fa30a21cdbabc15287d"
+        hash_of_git_diff = "a29864cf5600b481056b6fa30a21cdbabc15287d"[:8]
         fake_repo.git.describe.return_value = git_describe_val
         fake_repo.git.diff.return_value = "test-diff"  # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
         repo.return_value = fake_repo

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -34,12 +34,12 @@ def test_install_from_path():
         git_describe_val = "v0.65.1-1-g74a7a67-dirty"
         hash_of_git_diff = "a29864cf5600b481056b6fa30a21cdbabc15287d"
         fake_repo.git.describe.return_value = git_describe_val
-        fake_repo.git.diff.return_value = "test-diff" # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
+        fake_repo.git.diff.return_value = "test-diff"  # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
         repo.return_value = fake_repo
         version_str = "path:/where/grype/is/cloned"
         normalized_version_str = version_str.replace("/", "_").removeprefix("path:")
-        expected_grype_path = f".yardstick/tools/grype/{normalized_version_str}/{git_describe_val}-{hash_of_git_diff}/local_install"
-        tool = Grype.install(
-            version=version_str, path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False
+        expected_grype_path = (
+            f".yardstick/tools/grype/{normalized_version_str}/{git_describe_val}-{hash_of_git_diff}/local_install"
         )
+        tool = Grype.install(version=version_str, path=".yardstick/tools/grype/path:_where_grype_is_cloned", update_db=False)
         assert tool.path == expected_grype_path


### PR DESCRIPTION
Add the ability to install `grype` from a local path. Fixes https://github.com/anchore/yardstick/issues/108.

Before this change, yardstick could be configured to install grype from a remote repository, or from a published released. But yardstick is used as part of the quality tests in grype. Therefore, when iterating on those tests, it's valuable to have a mechanism to point yardstick at a local directory that can build grype; otherwise changes have to be committed and pushed at least to a branch before yardstick can use them.

Example of the new config:

``` yaml
        - name: grype
          # version: git:current-commit
          version: path:/Users/willmurphy/work/grype
          takes: SBOM

```

The above config will cause yardstick to compile grype from the source found at `/Users/willmurphy/work/grype`.

Here's an example of how the version is logged:

```
 Results used:
    ├── 2a3d3f2f-ea4f-48ca-a826-176f77a5c302 : grype@path:/Users/willmurphy/work/grype against ...
```

Yardstick replaces `/` with `_` in the path when saving the tool:

```
❯ ls .yardstick/tools/grype
_Users_willmurphy_work_grype v0.65.1
```