### PR TITLE
Allow for single grype installation with multiple shared DBs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 CHANGELOG.md
 VERSION
 .tmp/
+.tool-versions
 
 .idea/
 .vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ omitempty = "^0.1.1"
 importlib-metadata = "^6.7.0"
 mergedeep = "^1.3.4"
 dataclass-wizard = "^0.22.2"
-PyYAML = ">= 5.4.1, < 6.0"  # note: required for enterprise
+PyYAML = ">= 5.4.1, < 7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest-mock = "^3.11.1"

--- a/src/yardstick/__init__.py
+++ b/src/yardstick/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Optional
 
@@ -9,9 +11,14 @@ def compare_results(
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
     matches_filter: Optional[callable] = None,
+    store_root: str | None = None,
 ) -> comparison.ByPreservedMatch:
     results = store.scan_result.load_by_descriptions(
-        descriptions=descriptions, year_max_limit=year_max_limit, year_from_cve_only=year_from_cve_only, skip_sbom_results=True
+        descriptions=descriptions,
+        year_max_limit=year_max_limit,
+        year_from_cve_only=year_from_cve_only,
+        skip_sbom_results=True,
+        store_root=store_root,
     )
 
     if matches_filter:
@@ -33,6 +40,7 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
     year_from_cve_only: bool = False,
     label_entries: Optional[list[artifact.LabelEntry]] = None,
     matches_filter: Optional[callable] = None,
+    store_root: str | None = None,
 ) -> tuple[
     list[artifact.ScanResult],
     list[artifact.LabelEntry],
@@ -54,6 +62,7 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
         skip_sbom_results=True,
         year_max_limit=year_max_limit,
         year_from_cve_only=year_from_cve_only,
+        store_root=store_root,
     )
 
     if matches_filter:
@@ -61,7 +70,11 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
             result.matches = matches_filter(result.matches)
 
     if not label_entries:
-        label_entries = store.labels.load_all(year_max_limit=year_max_limit, year_from_cve_only=year_from_cve_only)
+        label_entries = store.labels.load_all(
+            year_max_limit=year_max_limit,
+            year_from_cve_only=year_from_cve_only,
+            store_root=store_root,
+        )
 
     comparisons_by_result_id, stats_by_image_tool_pair = comparison.of_results_against_label(
         *results,

--- a/src/yardstick/__init__.py
+++ b/src/yardstick/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import Optional
 
@@ -11,7 +9,7 @@ def compare_results(
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
     matches_filter: Optional[callable] = None,
-    store_root: str | None = None,
+    store_root: Optional[str] = None,
 ) -> comparison.ByPreservedMatch:
     results = store.scan_result.load_by_descriptions(
         descriptions=descriptions,
@@ -40,7 +38,7 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
     year_from_cve_only: bool = False,
     label_entries: Optional[list[artifact.LabelEntry]] = None,
     matches_filter: Optional[callable] = None,
-    store_root: str | None = None,
+    store_root: Optional[str] = None,
 ) -> tuple[
     list[artifact.ScanResult],
     list[artifact.LabelEntry],

--- a/src/yardstick/__init__.py
+++ b/src/yardstick/__init__.py
@@ -47,7 +47,7 @@ def compare_results_against_labels(  # pylint: disable=too-many-arguments
     if not descriptions:
         raise RuntimeError("no descriptions provided")
 
-    logging.info(f"running label comparison with {descriptions}")
+    logging.debug(f"running label comparison with {descriptions}")
 
     results = store.scan_result.load_by_descriptions(
         descriptions,

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 import getpass
 import hashlib
@@ -541,7 +539,7 @@ class ScanRequest:
 @dataclass()
 class ResultState:
     request: ScanRequest
-    config: ScanConfiguration | None = None
+    config: ScanConfiguration = None
 
 
 @dataclass_json

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import getpass
 import hashlib

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -539,7 +539,7 @@ class ScanRequest:
 @dataclass()
 class ResultState:
     request: ScanRequest
-    config: ScanConfiguration
+    config: ScanConfiguration | None = None
 
 
 @dataclass_json

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -161,6 +161,8 @@ def result_set(
                     )
 
         if refresh or not scan_config:
+            if scan_config:
+                logging.trace(f"replacing existing scan config {scan_config!r}")
             scan_config = one(scan_request, producer_state=producer_data_path, profiles=profiles)
 
         if not scan_config:

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -81,20 +81,6 @@ def intake(config: artifact.ScanConfiguration, raw_results: str) -> artifact.Sca
     return artifact.ScanResult(config=config, metadata=metadata, **keys)
 
 
-def summarize_image(image: str):
-    if "@sha256:" in image:
-        fields = image.split("@", 1)
-        return f"{fields[0]}@{fields[1][:15]}…"
-    return image
-
-
-def summarize_tool(tool: str):
-    if "+import-db=" in tool:
-        fields = tool.split("+import-db=", 1)
-        return f"{fields[0]}+import-db=…"
-    return tool
-
-
 def one(
     request: artifact.ScanRequest,
     producer_state: Optional[str] = None,
@@ -125,7 +111,7 @@ def one(
     return scan_config
 
 
-# pylint: disable=too-many-branches, too-many-locals
+# pylint: disable=too-many-locals
 def result_set(
     result_set: str,  # pylint: disable=redefined-outer-name
     scan_requests: list[artifact.ScanRequest],
@@ -171,18 +157,8 @@ def result_set(
 
                 if scan_config:
                     logging.info(f"using existing scan result {scan_config.ID}")
-                else:
-                    logging.debug(f"unable to find existing scan result by description={result_state.config.path}")
-
-            else:
-                logging.debug("unable to find existing scan result (missing config)")
-
-        else:
-            logging.debug(f"unable to find existing result set {result_set!r}")
 
         if refresh or not scan_config:
-            if scan_config:
-                logging.debug(f"replacing existing scan config {scan_config!r}")
             scan_config = one(scan_request, producer_state=producer_data_path, profiles=profiles)
 
         if not scan_config:

--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -60,6 +60,9 @@ class ResultSet:
     declared: list[artifact.ScanRequest] = field(default_factory=list)
     matrix: ScanMatrix = field(default_factory=ScanMatrix)
 
+    def images(self) -> list[str]:
+        return self.matrix.images + [req.image for req in self.declared]
+
     def scan_requests(self) -> list[artifact.ScanRequest]:
         rendered = []
         for image in self.matrix.images:

--- a/src/yardstick/comparison.py
+++ b/src/yardstick/comparison.py
@@ -613,13 +613,13 @@ def of_results_against_label(
     label_entries,
     fuzzy_package_match: bool = False,
 ) -> tuple[dict[str, list[AgainstLabels]], ImageToolLabelStats]:
-    logging.info("starting comparison against labels")
+    logging.debug("starting comparison against labels")
 
     comparisons_by_result_id = {}
 
     comparisons = []
     for result in results:
-        logging.info(f"comparing labels for image={result.config.image} tool={result.config.tool}")
+        logging.debug(f"comparing labels for image={result.config.image} tool={result.config.tool}")
 
         lineage = store.image_lineage.get(image=result.config.image)
         comp = AgainstLabels(result=result, label_entries=label_entries, lineage=lineage, fuzzy_package_match=fuzzy_package_match)

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 import glob
 import json
@@ -17,7 +15,7 @@ from yardstick.utils import remove_prefix
 LABELS_DIR = "labels"
 
 
-def label_store_root(store_root: str = None) -> str:
+def label_store_root(store_root: Optional[str] = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
     return os.path.join(store_root, LABELS_DIR)
@@ -29,12 +27,14 @@ def store_filename_by_entry(entry: artifact.LabelEntry) -> str:
     return f"{entry.ID}.json"
 
 
-def store_path(filename: str, store_root: str = None) -> str:
+def store_path(filename: str, store_root: Optional[str] = None) -> str:
     return os.path.join(label_store_root(store_root=store_root), filename)
 
 
 def append_and_update(
-    new_and_modified_entries: List[artifact.LabelEntry], delete_entries: List[artifact.LabelEntry] = None, store_root: str = None
+    new_and_modified_entries: List[artifact.LabelEntry],
+    delete_entries: List[artifact.LabelEntry] = None,
+    store_root: Optional[str] = None,
 ) -> List[artifact.LabelEntry]:
     for label_entry in delete_entries:
         filepath = store_path(filename=store_filename_by_entry(entry=label_entry))
@@ -50,7 +50,7 @@ def append_and_update(
     save(label_entries=new_and_modified_entries, store_root=store_root)
 
 
-def delete(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
+def delete(label_ids_to_delete: List[str], store_root: Optional[str] = None) -> List[str]:
     """delete_entries takes a list of ids to be deleted and returns a list of deleted files.
     FileNotFound exceptions are ignored."""
     label_store_dir = label_store_root(store_root=store_root)
@@ -69,7 +69,7 @@ def delete(label_ids_to_delete: List[str], store_root: str = None) -> List[str]:
     return deleted_ids
 
 
-def save(label_entries: List[artifact.LabelEntry], store_root: str = None):
+def save(label_entries: List[artifact.LabelEntry], store_root: Optional[str] = None):
     root_path = label_store_root(store_root=store_root)
     logging.debug(f"storing all labels location={root_path}")
 
@@ -107,7 +107,7 @@ def save(label_entries: List[artifact.LabelEntry], store_root: str = None):
 
 
 def load_label_file(
-    filename: str, year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    filename: str, year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: Optional[str] = None
 ) -> List[artifact.LabelEntry]:
     # why note take a file path? in this way we control that all input/output data was derived from the same store,
     # and not another store.
@@ -136,7 +136,7 @@ def load_label_file(
 
 
 def load_all(
-    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str | None = None
+    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: Optional[str] = None
 ) -> List[artifact.LabelEntry]:
     root_path = label_store_root(store_root=store_root)
     logging.debug(f"loading all labels (location={root_path})")
@@ -158,7 +158,10 @@ def load_all(
 
 
 def load_for_image(
-    images: Union[str, List[str]], year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    images: Union[str, List[str]],
+    year_max_limit: Optional[int] = None,
+    year_from_cve_only: bool = False,
+    store_root: Optional[str] = None,
 ) -> List[artifact.LabelEntry]:
     root_path = label_store_root(store_root=store_root)
     if isinstance(images, str):

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import glob
 import json
@@ -115,7 +117,7 @@ def load_label_file(
 
 
 def load_all(
-    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str = None
+    year_max_limit: Optional[int] = None, year_from_cve_only: bool = False, store_root: str | None = None
 ) -> List[artifact.LabelEntry]:
     root_path = label_store_root(store_root=store_root)
     logging.debug(f"loading all labels (location={root_path})")

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import copy
 import glob
 import itertools
@@ -16,21 +14,23 @@ from yardstick.store import naming, tool
 from yardstick.tool import sbom_generator, tools, vulnerability_scanner
 
 
-def _store_root(store_root: str = None):
+def _store_root(store_root: Optional[str] = None):
     if not store_root:
         store_root = store_config.get().store_root
 
     return tool.results_path(store_root=store_root)
 
 
-def clear(store_root: str = None):
+def clear(store_root: Optional[str] = None):
     try:
         shutil.rmtree(_store_root(store_root=store_root))
     except FileNotFoundError:
         pass
 
 
-def store_paths(config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX, store_root: str = None) -> Tuple[str, str]:
+def store_paths(
+    config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX, store_root: Optional[str] = None
+) -> Tuple[str, str]:
     # repo@digest/tool@version/timestamp/data.json
     # repo@digest/tool@version/timestamp/metadata.json
 
@@ -46,7 +46,7 @@ def store_paths(config: artifact.ScanConfiguration, suffix: str = naming.SUFFIX,
 
 
 # note: we intentionally split up the data and metadata such that matches are recomputed with the latest code changes
-def save(raw: str, results: artifact.ScanResult, store_root: str = None):
+def save(raw: str, results: artifact.ScanResult, store_root: Optional[str] = None):
     if not isinstance(results, artifact.ScanResult):
         raise RuntimeError(f"only ScanResult is supported, given {type(results)}")
 
@@ -75,7 +75,7 @@ def find(
     by_tool: str = "",
     by_time: str = "",
     by_description: str = "",
-    store_root: str = None,
+    store_root: Optional[str] = None,
 ) -> List[artifact.ScanConfiguration]:
     json_path = tool.results_path(store_root=store_root)
 
@@ -159,7 +159,7 @@ def load_by_descriptions(
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
     skip_sbom_results: bool = False,
-    store_root: str | None = None,
+    store_root: Optional[str] = None,
 ) -> list[artifact.ScanResult]:
     results = []
     for description in descriptions:
@@ -177,7 +177,7 @@ def load_all(
     configs: list[artifact.ScanConfiguration],
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
-    store_root: str = None,
+    store_root: Optional[str] = None,
 ) -> list[artifact.ScanResult]:
     return [
         load(config, year_max_limit=year_max_limit, year_from_cve_only=year_from_cve_only, store_root=store_root)
@@ -190,7 +190,7 @@ def load(
     config: artifact.ScanConfiguration,
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
-    store_root: str = None,
+    store_root: Optional[str] = None,
 ) -> artifact.ScanResult:
     data_path, metadata_path = store_paths(config, store_root=store_root)
     logging.debug(f"loading result config={config!r} location={data_path!r}")
@@ -233,12 +233,12 @@ def load(
     return result_obj
 
 
-def list_all_metadata_json(store_root: str = None):
+def list_all_metadata_json(store_root: Optional[str] = None):
     json_path = tool.results_path(store_root=store_root)
     return glob.glob(f"{json_path}/*/*/*/metadata.json")
 
 
-def list_all_configs(store_root: str = None) -> List[artifact.ScanConfiguration]:
+def list_all_configs(store_root: Optional[str] = None) -> List[artifact.ScanConfiguration]:
     results = []
     for metadata_file in list_all_metadata_json(store_root=store_root):
         with open(metadata_file, "r", encoding="utf-8") as metadata_file:

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -163,7 +163,7 @@ def load_by_descriptions(
         result = load(config=config, year_max_limit=year_max_limit, year_from_cve_only=year_from_cve_only, store_root=store_root)
         if skip_sbom_results and result.packages is not None:
             # note: we look at a NONE value, not just an empty list
-            logging.info(f"skipping SBOM result from {description}")
+            logging.debug(f"skipping SBOM result from {description}")
             continue
         results.append(result)
     return results

--- a/src/yardstick/store/scan_result.py
+++ b/src/yardstick/store/scan_result.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import glob
 import itertools
@@ -119,6 +121,8 @@ def find(
 
     glob_str = f"{json_path}/{search_tuple}/metadata.json"
 
+    logging.debug(f"searching for {glob_str}")
+
     for metadata_file in glob.glob(glob_str):
         image_tool_dir = os.path.dirname(os.path.dirname(metadata_file))
         with open(metadata_file, "r", encoding="utf-8") as fd:
@@ -155,7 +159,7 @@ def load_by_descriptions(
     year_max_limit: Optional[int] = None,
     year_from_cve_only: bool = False,
     skip_sbom_results: bool = False,
-    store_root: str = None,
+    store_root: str | None = None,
 ) -> list[artifact.ScanResult]:
     results = []
     for description in descriptions:

--- a/src/yardstick/store/tool.py
+++ b/src/yardstick/store/tool.py
@@ -8,15 +8,26 @@ RESULT_DIR = os.path.join("result", "store")
 RESULT_SET_DIR = os.path.join("result", "sets")
 
 
+def install_base(name: str, store_root: str = None) -> str:
+    if not store_root:
+        store_root = store_config.get().store_root
+
+    return os.path.join(store_config.get().store_root, TOOL_DIR, name.replace("/", "_"))
+
+
 def install_path(config: artifact.ScanConfiguration, store_root: str = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
 
+    store_base = install_base(name=config.tool_name, store_root=store_root)
+
+    version = config.tool_version
+    if config.tool_name.startswith("grype"):
+        version = version.split("+import-db=")[0]
+
     return os.path.join(
-        store_root,
-        TOOL_DIR,
-        config.tool_name.replace("/", "_"),
-        config.tool_version.replace("/", "_"),
+        store_base,
+        version.replace("/", "_"),
     )
 
 

--- a/src/yardstick/store/tool.py
+++ b/src/yardstick/store/tool.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from yardstick import artifact
 from yardstick.store import config as store_config
@@ -8,14 +9,14 @@ RESULT_DIR = os.path.join("result", "store")
 RESULT_SET_DIR = os.path.join("result", "sets")
 
 
-def install_base(name: str, store_root: str = None) -> str:
+def install_base(name: str, store_root: Optional[str] = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
 
     return os.path.join(store_config.get().store_root, TOOL_DIR, name.replace("/", "_"))
 
 
-def install_path(config: artifact.ScanConfiguration, store_root: str = None) -> str:
+def install_path(config: artifact.ScanConfiguration, store_root: Optional[str] = None) -> str:
     if not store_root:
         store_root = store_config.get().store_root
 
@@ -31,14 +32,14 @@ def install_path(config: artifact.ScanConfiguration, store_root: str = None) -> 
     )
 
 
-def results_path(store_root: str = None):
+def results_path(store_root: Optional[str] = None):
     if not store_root:
         store_root = store_config.get().store_root
 
     return os.path.join(store_root, RESULT_DIR)
 
 
-def result_set_path(store_root: str = None):
+def result_set_path(store_root: Optional[str] = None):
     if not store_root:
         store_root = store_config.get().store_root
 

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -47,8 +47,8 @@ class Grype(VulnerabilityScanner):
             if self.profile and self.profile.name:
                 self.version_detail += f"+profile={self.profile.name}"
 
-    @functools.cache
     @staticmethod
+    @functools.cache
     def latest_version_from_github():
         return github.get_latest_release_version(project="grype")
 

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -7,8 +7,8 @@ import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
 import tarfile
+import tempfile
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -285,10 +285,24 @@ class Grype(VulnerabilityScanner):
             version,
         ):
             tool_obj = cls._install_from_installer(
-                version=version, path=path, within_path=within_path, use_cache=use_cache, profile=grype_profile, db_identity=db_identity, **kwargs
+                version=version,
+                path=path,
+                within_path=within_path,
+                use_cache=use_cache,
+                profile=grype_profile,
+                db_identity=db_identity,
+                **kwargs,
             )
         else:
-            tool_obj = cls._install_from_git(version=version, path=path, within_path=within_path, use_cache=use_cache, profile=grype_profile, db_identity=db_identity, **kwargs)
+            tool_obj = cls._install_from_git(
+                version=version,
+                path=path,
+                within_path=within_path,
+                use_cache=use_cache,
+                profile=grype_profile,
+                db_identity=db_identity,
+                **kwargs,
+            )
 
         # always update the DB, raise exception on failure
         if db_import_path:

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -89,7 +89,7 @@ class Grype(VulnerabilityScanner):
         return Grype(path=path, version_detail=version, **kwargs)
 
     @classmethod
-    def _install_from_git(  # pylint: disable=too-many-branches
+    def _install_from_git(
         cls,
         version: str,
         path: Optional[str] = None,

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -28,8 +28,8 @@ class Syft(SBOMGenerator):
         if version_detail:
             self.version_detail = version_detail
 
-    @functools.cache
     @staticmethod
+    @functools.cache
     def latest_version_from_github():
         return github.get_latest_release_version(project="syft")
 

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -45,9 +45,13 @@ class Syft(SBOMGenerator):
             atexit.register(shutil.rmtree, path)
         elif within_path:
             path = os.path.join(within_path, version)
-            os.makedirs(path, exist_ok=True)
-            if os.path.exists(os.path.join(path, "syft")):
-                tool_exists = True
+
+        if not path:
+            raise ValueError("no path found to install syft")
+
+        os.makedirs(path, exist_ok=True)
+        if os.path.exists(os.path.join(path, "syft")):
+            tool_exists = True
 
         if not tool_exists:
             subprocess.check_call(

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -169,7 +169,9 @@ class Syft(SBOMGenerator):
             r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
             version,
         ):
-            tool_obj = cls._install_from_installer(version=version, path=path,within_path=within_path, use_cache=use_cache, **kwargs)
+            tool_obj = cls._install_from_installer(
+                version=version, path=path, within_path=within_path, use_cache=use_cache, **kwargs
+            )
         else:
             tool_obj = cls._install_from_git(version=version, path=path, within_path=within_path, use_cache=use_cache, **kwargs)
 

--- a/src/yardstick/utils/__init__.py
+++ b/src/yardstick/utils/__init__.py
@@ -6,7 +6,7 @@ import os
 
 import git
 
-from . import grype_db
+from . import github, grype_db
 
 
 def local_build_version_suffix(src_path: str) -> str:

--- a/src/yardstick/utils/github.py
+++ b/src/yardstick/utils/github.py
@@ -1,0 +1,22 @@
+import logging
+import os
+
+import requests
+
+
+def get_latest_release_version(project: str, owner: str = "anchore") -> str:
+    headers = {}
+    if os.environ.get("GITHUB_TOKEN") is not None:
+        headers["Authorization"] = "Bearer " + os.environ.get("GITHUB_TOKEN")
+
+    response = requests.get(
+        f"https://api.github.com/repos/{owner}/{project}/releases/latest",
+        headers=headers,
+    )
+
+    if response.status_code >= 400:
+        logging.error(f"error while fetching latest {project} version: {response.status_code}: {response.reason} {response.text}")
+
+    response.raise_for_status()
+
+    return response.json()["name"]

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -10,7 +10,7 @@ def test_grype_profiles():
     profile = GrypeProfile(**profile_arg)
     with mock.patch("subprocess.check_output") as check_output:
         check_output.return_value = bytes("test-output", "utf-8")
-        tool = Grype(path="test-path", profile=profile)
+        tool = Grype(path="test-path", profile=profile, db_identity="oss")
         tool.capture(image="test-image", tool_input=None)
         assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image", "-c", "test-config-path"]
 
@@ -18,7 +18,7 @@ def test_grype_profiles():
 def test_grype_no_profile():
     with mock.patch("subprocess.check_output") as check_output:
         check_output.return_value = bytes("test-output", "utf-8")
-        tool = Grype(path="test-path")
+        tool = Grype(path="test-path", db_identity="oss")
         tool.capture(image="test-image", tool_input=None)
         assert check_output.call_args.args[0] == ["test-path/grype", "-o", "json", "test-image"]
 


### PR DESCRIPTION
This PR allows for a single installation of grype share multiple DB and track by the checksum of the DB (or is as `oss`).

It was noticed while working on this that:
- the root yardstick functions (such as `compare_results`) do not allow for passing an optional `store_root` as done elsewhere. This option has been added.
- some adjustments to logging where done to shorten the output, such as bump some log lines from info to debug ~and to summarize long tool and image strings intelligently~ (edit: descoped)
- add debug logging when hitting negative cases for capturing a result
- note explicitly in logging when a scan configuration is being replaced in a result set
- in the files I modified I tried to make the type hint annotations more accurate
