### PR TITLE
feat: add "path:" syntax for syft tool

### DIFF
--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -144,6 +144,7 @@ class Grype(VulnerabilityScanner):
 
         abspath = os.path.abspath(path)
         if not tool_exists:
+            logging.debug(f"installing grype to {abspath!r}")
             cls._run_go_build(
                 abs_install_dir=abspath,
                 repo_path=repo_path,

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -1,5 +1,4 @@
 import atexit
-import hashlib
 import json
 import logging
 import os
@@ -157,36 +156,6 @@ class Grype(VulnerabilityScanner):
         return Grype(path=path, version_detail=description, **kwargs)
 
     @classmethod
-    def _local_build_version_suffix(cls, src_path: str) -> str:
-        src_path = os.path.abspath(os.path.expanduser(src_path))
-        git_desc = ""
-        diff_digest = "clean"
-        try:
-            repo = git.Repo(src_path)
-        except:
-            logging.error(f"failed to open existing grype repo at {src_path!r}")
-            raise
-        git_desc = repo.git.describe("--tags", "--always", "--long", "--dirty")
-        if repo.is_dirty():
-            hash_obj = hashlib.sha1()
-            for untracked in repo.untracked_files:
-                hash_obj.update(cls._hash_file(os.path.join(repo.working_dir, untracked)).encode())
-            hash_obj.update(repo.git.diff("HEAD").encode())
-            diff_digest = hash_obj.hexdigest()[:8]
-        return f"{git_desc}-{diff_digest}"
-
-    @classmethod
-    def _hash_file(cls, path: str) -> str:
-        hash_obj = hashlib.sha1()
-        with open(path, "rb") as f:
-            while True:
-                data = f.read(4096)
-                if not data:
-                    break
-                hash_obj.update(data)
-        return hash_obj.hexdigest()
-
-    @classmethod
     def _install_from_path(
         cls,
         path: Optional[str],
@@ -195,7 +164,7 @@ class Grype(VulnerabilityScanner):
     ) -> "Grype":
         # get the description and head ref from the repo
         src_repo_path = os.path.abspath(os.path.expanduser(src_path))
-        build_version = cls._local_build_version_suffix(src_repo_path)
+        build_version = utils.local_build_version_suffix(src_repo_path)
         logging.debug(f"installing grype from path={src_repo_path!r}")
         logging.debug(f"installing grype to path={path!r}")
         if not path:

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -17,6 +17,7 @@ from yardstick import artifact, utils
 from yardstick.tool.sbom_generator import SBOMGenerator
 
 
+# pylint: disable=no-member
 class Syft(SBOMGenerator):
     _latest_version_from_github: Optional[str] = None
 
@@ -72,6 +73,15 @@ class Syft(SBOMGenerator):
         logging.debug(f"installing syft version={version!r} from git")
         tool_exists = False
 
+        repo_url = "github.com/anchore/syft"
+        if version.startswith("github.com"):
+            repo_url = version
+            if "@" in version:
+                version = version.split("@")[1]
+                repo_url = repo_url.split("@")[0]
+            else:
+                version = "main"
+
         if not use_cache and path:
             shutil.rmtree(path, ignore_errors=True)
 
@@ -85,12 +95,16 @@ class Syft(SBOMGenerator):
         if os.path.exists(repo_path):
             logging.debug(f"found existing syft repo at {repo_path!r}")
             # use existing source
-            repo = git.Repo(repo_path)
+            try:
+                repo = git.Repo(repo_path)
+            except:
+                logging.error(f"failed to open existing syft repo at {repo_path!r}")
+                raise
         else:
-            logging.debug("cloning the syft git repo")
+            logging.debug("cloning the syft git repo: {repo_url!r}")
             # clone the repo
             os.makedirs(repo_path)
-            repo = git.Repo.clone_from("https://github.com/anchore/syft.git", repo_path)
+            repo = git.Repo.clone_from("https://{repo_url}.git", repo_path)
 
         # checkout the ref in question
         repo.git.fetch("origin", version)
@@ -110,22 +124,104 @@ class Syft(SBOMGenerator):
         abspath = os.path.abspath(path)
         if not tool_exists:
             logging.debug(f"installing syft to {abspath!r}")
-            # pylint: disable=line-too-long
-            c = f"go build -ldflags \"-w -s -extldflags '-static' -X github.com/anchore/syft/internal/version.version={description}\" -o {abspath} ./cmd/syft/"
-            logging.debug(f"running {c!r}")
-            subprocess.check_call(
-                shlex.split(c),
-                stdout=sys.stdout,
-                stderr=sys.stderr,
-                cwd=repo_path,
-                env=dict(**{"GOBIN": abspath, "CGO_ENABLED": "0"}, **os.environ),
-            )
-
-            os.chmod(f"{path}/syft", 0o755)
+            cls._run_go_build(abs_install_dir=abspath, repo_path=repo_path, description=description, binpath=path)
         else:
             logging.debug(f"using existing syft installation {abspath!r}")
 
         return Syft(path=path, version_detail=description)
+
+    @classmethod
+    def _local_build_version_suffix(cls, src_path: str) -> str:
+        src_path = os.path.abspath(os.path.expanduser(src_path))
+        git_desc = ""
+        diff_digest = "clean"
+        try:
+            repo = git.Repo(src_path)
+        except:
+            logging.error(f"failed to open existing grype repo at {src_path!r}")
+            raise
+        git_desc = repo.git.describe("--tags", "--always", "--long", "--dirty")
+        if repo.is_dirty():
+            hash_obj = hashlib.sha1()
+            for untracked in repo.untracked_files:
+                hash_obj.update(cls._hash_file(os.path.join(repo.working_dir, untracked)).encode())
+            hash_obj.update(repo.git.diff("HEAD").encode())
+            diff_digest = hash_obj.hexdigest()[:8]
+        return f"{git_desc}-{diff_digest}"
+
+    @classmethod
+    def _install_from_path(
+        cls,
+        path: Optional[str],
+        src_path: str,
+    ) -> "Syft":
+        # get the description and head ref from the repo
+        src_repo_path = os.path.abspath(os.path.expanduser(src_path))
+        build_version = cls._local_build_version_suffix(src_repo_path)
+        logging.debug(f"installing syft from path={src_repo_path!r}")
+        logging.debug(f"installing syft to path={path!r}")
+        if not path:
+            path = tempfile.mkdtemp()
+            atexit.register(shutil.rmtree, path)
+        dest_path = os.path.join(path.replace("path:", ""), build_version, "local_install")
+        os.makedirs(dest_path, exist_ok=True)
+        cls._run_go_build(
+            abs_install_dir=os.path.abspath(dest_path),
+            description=f"{path}:{build_version}",
+            repo_path=src_repo_path,
+            binpath=dest_path,
+        )
+
+        return Syft(path=dest_path)
+
+    @staticmethod
+    def _run_go_build(
+        abs_install_dir: str,
+        repo_path: str,
+        description: str,
+        binpath: str,
+        version_ref: str = "github.com/anchore/syft/internal/version.version",
+    ):
+        logging.debug(f"installing syft via build to {abs_install_dir!r}")
+
+        main_pkg_path = "./cmd/syft"
+        if not os.path.exists(os.path.join(repo_path, "cmd", "syft", "main.go")):
+            # support legacy installations, when the main.go was in the root of the repo
+            main_pkg_path = "."
+
+        c = f"go build -ldflags \"-w -s -extldflags '-static' -X {version_ref}={description}\" -o {abs_install_dir} {main_pkg_path}"
+        logging.debug(f"running {c!r}")
+
+        e = {"GOBIN": abs_install_dir, "CGO_ENABLED": "0"}
+        e.update(os.environ)
+
+        subprocess.check_call(
+            shlex.split(c),
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            cwd=repo_path,
+            env=e,
+        )
+
+        os.chmod(f"{binpath}/syft", 0o755)
+
+    @classmethod
+    def _get_latest_version_from_github(cls) -> str:
+        headers = {}
+        if os.environ.get("GITHUB_TOKEN") is not None:
+            headers["Authorization"] = "Bearer " + os.environ.get("GITHUB_TOKEN")
+
+        response = requests.get(
+            "https://api.github.com/repos/anchore/syft/releases/latest",
+            headers=headers,
+        )
+
+        if response.status_code >= 400:
+            logging.error(f"error while fetching latest syft version: {response.status_code}: {response.reason} {response.text}")
+
+        response.raise_for_status()
+
+        return response.json()["name"]
 
     @classmethod
     def install(cls, version: str, path: Optional[str] = None, use_cache: Optional[bool] = True, **kwargs) -> "Syft":
@@ -135,10 +231,8 @@ class Syft(SBOMGenerator):
                 logging.info(f"latest syft release found (cached) is {version}")
 
             else:
-                response = requests.get("https://api.github.com/repos/anchore/syft/releases/latest")
-                version = response.json()["name"]
+                version = cls._get_latest_version_from_github()
                 cls._latest_version_from_github = version
-
                 path = os.path.join(os.path.dirname(path), version)
                 logging.info(f"latest syft release found is {version}")
 
@@ -149,6 +243,11 @@ class Syft(SBOMGenerator):
             version,
         ):
             tool_obj = cls._install_from_installer(version=version, path=path, use_cache=use_cache, **kwargs)
+        elif version.startswith("path"):
+            tool_obj = cls._install_from_path(
+                path=path,
+                src_path=version.removeprefix("path:"),
+            )
         else:
             tool_obj = cls._install_from_git(version=version, path=path, use_cache=use_cache, **kwargs)
 

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -245,7 +245,7 @@ class Syft(SBOMGenerator):
             version,
         ):
             tool_obj = cls._install_from_installer(version=version, path=path, use_cache=use_cache, **kwargs)
-        elif version.startswith("path"):
+        elif version.startswith("path:"):
             tool_obj = cls._install_from_path(
                 path=path,
                 src_path=version.removeprefix("path:"),

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -1,5 +1,4 @@
 import atexit
-import hashlib
 import json
 import logging
 import os
@@ -133,25 +132,6 @@ class Syft(SBOMGenerator):
         return Syft(path=path, version_detail=description)
 
     @classmethod
-    def _local_build_version_suffix(cls, src_path: str) -> str:
-        src_path = os.path.abspath(os.path.expanduser(src_path))
-        git_desc = ""
-        diff_digest = "clean"
-        try:
-            repo = git.Repo(src_path)
-        except:
-            logging.error(f"failed to open existing grype repo at {src_path!r}")
-            raise
-        git_desc = repo.git.describe("--tags", "--always", "--long", "--dirty")
-        if repo.is_dirty():
-            hash_obj = hashlib.sha1()
-            for untracked in repo.untracked_files:
-                hash_obj.update(cls._hash_file(os.path.join(repo.working_dir, untracked)).encode())
-            hash_obj.update(repo.git.diff("HEAD").encode())
-            diff_digest = hash_obj.hexdigest()[:8]
-        return f"{git_desc}-{diff_digest}"
-
-    @classmethod
     def _install_from_path(
         cls,
         path: Optional[str],
@@ -159,7 +139,7 @@ class Syft(SBOMGenerator):
     ) -> "Syft":
         # get the description and head ref from the repo
         src_repo_path = os.path.abspath(os.path.expanduser(src_path))
-        build_version = cls._local_build_version_suffix(src_repo_path)
+        build_version = utils.local_build_version_suffix(src_repo_path)
         logging.debug(f"installing syft from path={src_repo_path!r}")
         logging.debug(f"installing syft to path={path!r}")
         if not path:

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -1,4 +1,5 @@
 import atexit
+import hashlib
 import json
 import logging
 import os
@@ -65,6 +66,7 @@ class Syft(SBOMGenerator):
 
     @staticmethod
     def _install_from_git(
+        cls,
         version: str,
         path: Optional[str] = None,
         use_cache: Optional[bool] = True,

--- a/src/yardstick/tool/syft.py
+++ b/src/yardstick/tool/syft.py
@@ -64,7 +64,7 @@ class Syft(SBOMGenerator):
 
         return Syft(path=path)
 
-    @staticmethod
+    @classmethod
     def _install_from_git(
         cls,
         version: str,


### PR DESCRIPTION
## Summary
Similar to https://github.com/anchore/yardstick/pull/111 - Adds the ability to install syft from local path.

When making updates to the SBOM that grype consumes it's important to allow local development on syft so that developers can test their changes E2E before submitting major changes to things that might affect matching logic such as PURL/CPE.

This change allows developers to use a build based on their local `syft` to experiment with different SBOM changes.

New Config Example that uses local syft changes against changes in grype and the stable latest
```
result-sets:
  example:
    description: "latest released grype vs grype from the current build"
    matrix:
      images: *images
      tools:
        - name: syft
          # note: we want to use a fixed version of syft for capturing all results (NOT "latest")
          version: path:/Users/me/development/syft
          produces: SBOM
          refresh: false

        - name: grype
          # for local build of grype, use for example:
          version: path:/Users/me/development/grype
          takes: SBOM

        - name: grype
          version: latest
          takes: SBOM

```

How it's shown in results:
```
0d1799c89-63c6-4290-81bc-7e89cc2b3b9a  docker.io/anchore/test_images@sha256:10008791acbc5866de04108746a02a0c4029ce3a4400a9b3dad45d7f2245f9da           syft@path:/Users/hal/GolandProjects/syft    2023-08-16 17:38:40.589609+00:00
```