### PR TITLE
Update README to correct yardstick.yaml examples and fix env var parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ result-sets:
       images:
         - ubuntu:20.04
       tools:
-        - grype@v0.32.0
-        - grype@v0.48.0
-
+        - name: grype
+          version: v0.32.0
+        - name: grype
+          version: v0.48.0
 ```
 
 ```bash
@@ -86,10 +87,12 @@ result-sets:
     matrix:
       images: *images
       tools:
-        - syft@v0.54.0                    # go ahead and capture an SBOM each time to help analysis later
-        - grype@latest                    # from the latest published github release
-        - grype@env:CURRENT_GRYPE_COMMIT  # from a local PR checkout install (feed via an environment variable)
-
+        - name: syft                      # go ahead and capture an SBOM each time to help analysis later
+          version: v0.54.0                
+        - name: grype                     # from the latest published github release
+          version: latest
+        - name: grype:pr                  # from a local PR checkout install (feed via an environment variable)
+          version: env:CURRENT_GRYPE_COMMIT
 ```
 
 ## CLI Commands

--- a/README.md
+++ b/README.md
@@ -88,11 +88,16 @@ result-sets:
       images: *images
       tools:
         - name: syft                      # go ahead and capture an SBOM each time to help analysis later
-          version: v0.54.0                
+          version: v0.54.0
+          produces: SBOM
+
         - name: grype                     # from the latest published github release
           version: latest
+          takes: SBOM
+
         - name: grype:pr                  # from a local PR checkout install (feed via an environment variable)
           version: env:CURRENT_GRYPE_COMMIT
+          takes: SBOM
 ```
 
 ## CLI Commands

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -570,7 +570,10 @@ class ScanRequest:
 
         if "@env:" in tool:
             name, val = tool.split("@env:")
-            val, metadata = val.split("+", 1)
+            if "+" in val:
+                val, metadata = val.split("+", 1)
+            else:
+                metadata = None
             # preserve the name and any other suffix
             tool = f"{name}@{os.environ[val]}"
             if metadata:


### PR DESCRIPTION
- The yardstick.yaml "tools" sections needed to be updated to specify name and version of tools separately
- The config parser can now handle environment variables like `version: env:CURRENT_GRYPE_COMMIT` even if no metadata is provided (like `version: env:CURRENT_GRYPE_COMMIT+metadata`)