### PR TITLE
Run validations PRs from forks

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -1,7 +1,10 @@
 name: "Validations"
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently validations work best with in-repo branches, however, will not run on PRs from forks. This PR addresses this while still allowing for validations to run on the main branch on merge.