### PR TITLE
fix: upgrade cli test to account for `version: v0.72.0+import-db=db.tar.gz`

### DIFF
--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -127,7 +127,7 @@ class ScanConfiguration:
         ),
     )
     tool_input: Optional[str] = None
-    detail: Dict[str, dict] = field(default_factory=dict)
+    detail: Dict[str, str] = field(default_factory=dict)
     ID: str = field(default_factory=lambda: str(uuid.uuid4()))
 
     def __post_init__(self):

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -367,7 +367,7 @@ class Grype(VulnerabilityScanner):
 
         # patch the config with the db information found
         config.detail["db"] = utils.dig(obj, "descriptor", "db", default={})
-        db_location = config.detail["db"].get("location", None) # type: ignore[attr-defined]
+        db_location = config.detail["db"].get("location", None)  # type: ignore[attr-defined]
         if db_location:
             # we should always interpret results with the same DB if the DB is still there (e.g. to support
             # GHSA to CVE mapping for the latest results) if the DB is not there, we try to fall back to

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -367,7 +367,7 @@ class Grype(VulnerabilityScanner):
 
         # patch the config with the db information found
         config.detail["db"] = utils.dig(obj, "descriptor", "db", default={})
-        db_location = config.detail["db"].get("location", None)
+        db_location = config.detail["db"].get("location", None) # type: ignore[attr-defined]
         if db_location:
             # we should always interpret results with the same DB if the DB is still there (e.g. to support
             # GHSA to CVE mapping for the latest results) if the DB is not there, we try to fall back to

--- a/tests/cli/.gitignore
+++ b/tests/cli/.gitignore
@@ -1,2 +1,3 @@
 .yardstick/tools
 .yardstick/result
+*.tar.gz

--- a/tests/cli/.yardstick.yaml
+++ b/tests/cli/.yardstick.yaml
@@ -16,5 +16,5 @@ result-sets:
           version: v0.27.0
 
         - name: grype
-          version: v0.50.2
+          version: v0.72.0+import-db=db.tar.gz
           takes: SBOM

--- a/tests/cli/Makefile
+++ b/tests/cli/Makefile
@@ -1,5 +1,8 @@
 ACTIVATE_VENV = . venv/bin/activate &&
 
+TEST_DB_URL = https://toolbox-data.anchore.io/grype/databases/vulnerability-db_v5_2023-10-25T01:27:28Z_fd5a911f9285633c57e3.tar.gz
+TEST_DB = db.tar.gz
+
 # formatting variables
 BOLD := $(shell tput -T linux bold)
 PURPLE := $(shell tput -T linux setaf 5)
@@ -10,8 +13,11 @@ RESET := $(shell tput -T linux sgr0)
 TITLE := $(BOLD)$(PURPLE)
 SUCCESS := $(BOLD)$(GREEN)
 
-test: venv ## Run CLI tests
+test: venv $(TEST_DB) ## Run CLI tests
 	$(ACTIVATE_VENV) ./run.sh
+
+$(TEST_DB):
+	curl -o $(TEST_DB) -SsL $(TEST_DB_URL)
 
 venv: venv/touchfile ## Create a python virtual environment
 

--- a/tests/cli/run.sh
+++ b/tests/cli/run.sh
@@ -60,19 +60,19 @@ run yardstick result list -r test
 
 assert_last_output_length 3
 assert_last_output_contains "grype@v0.27.0"
-assert_last_output_contains "grype@v0.50.2"
+assert_last_output_contains "grype@v0.72.0"
 assert_last_output_contains "syft@v0.54.0"
 assert_last_output_contains "docker.io/anchore/test_images:java-56d52bc@sha256:10008791acbc5866de04108746a02a0c4029ce3a4400a9b3dad45d7f2245f9da"
 
 run yardstick result compare $(yardstick result list -r test --ids -t grype)
 
-assert_last_output_contains "grype-v0.50.2-only"
+assert_last_output_contains "grype-v0.72.0-only"
 assert_last_output_contains "commons-collections"
 assert_last_output_contains "dom4j"
 assert_last_output_contains "log4j"
 assert_last_output_contains "spring-core"
 
-run yardstick label apply $(yardstick result list -r test --ids -t grype@v0.50.2)
+run yardstick label apply $(yardstick result list -r test --ids -t grype@v0.72.0)
 
 assert_last_output_contains "label: TruePositive"
 


### PR DESCRIPTION
## Summary

It looks like https://github.com/anchore/yardstick/pull/143/files saw a change where `ScanConfiguration` had the `detail` type contract change. This change made it so that if `version_detail`was not set in the result data structure, the datacalsses library would throw an error:

```
  File "/Users/hal/development/yardstick/src/yardstick/cli/result.py", line 280, in result_descriptions
    result_set_obj = store.result_set.load(result_set)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hal/development/yardstick/src/yardstick/store/result_set.py", line 50, in load
    return artifact.ResultSet.from_json(data_json)  # type: ignore[attr-defined]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hal/development/yardstick/tests/cli/venv/lib/python3.11/site-packages/dataclasses_json/api.py", line 63, in from_json
    return cls.from_dict(kvs, infer_missing=infer_missing)
```

`version_detail` would only be set on certain conditions. One of these would be when using a version format like `version: v0.72.0+import-db=db.tar.gz`

This PR updates the test coverage to cover version statements that were throwing the above error, while reverting the change from #143.

I think after this is merged we can release a patch version `v0.9.1` This should allow the quality gate in grype to not error due to this bug.

Here is a sample of the current failing job:
https://github.com/anchore/grype/actions/runs/6659790042/job/18099619846?pr=1571#step:4:3170

While this doesn't make a ton of sense given that the actual type structure is `Dict[Optional[str], dict]`,  the data classes also throws an error for that configuration:
```
  File "/Users/hal/.local/share/rtx/installs/python/3.11.6/lib/python3.11/typing.py", line 465, in __call__
    raise TypeError(f"Cannot instantiate {self!r}")
TypeError: Cannot instantiate typing.Union
```

This PR seems like the best middle ground where we can get yardstick back to working, while deciding on what we should do going forward regarding use of the dataclasses patterns