### PR TITLE
chore: fix actions version hint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   quality-gate:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Check if tag already exists
         # note: this will fail if the tag already exists
         run: |
@@ -28,7 +28,7 @@ jobs:
           git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
 
       - name: Check validation results
-        uses: fountainhead/action-wait-for-check@297be350cf8393728ea4d4b39435c7d7ae167c93 #v1.1.0
+        uses: fountainhead/action-wait-for-check@297be350cf8393728ea4d4b39435c7d7ae167c93 # v1.1.0
         id: validations
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,14 +53,14 @@ jobs:
       issues: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           # in order to properly resolve the version from git
           fetch-depth: 0
 
       - name: Restore tool cache
         id: tool-cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: ${{ github.workspace }}/.tmp
           key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -19,19 +19,19 @@ jobs:
   validations:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c #v5.0.0
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install poetry
-        uses: abatilo/actions-poetry@437d4fa27baf74d89b789ba2d8cae97dd2365feb #v2.3.0
+        uses: abatilo/actions-poetry@437d4fa27baf74d89b789ba2d8cae97dd2365feb # v2.3.0
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Cache Poetry virtualenv
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3.3.3
+        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         id: cache
         with:
           path: ~/.virtualenvs


### PR DESCRIPTION
Fixes the version hints on used GitHub Actions so that dependabot can use them when creating PRs