### PR TITLE
Expand rules for ALAS year extraction

### DIFF
--- a/src/yardstick/utils/__init__.py
+++ b/src/yardstick/utils/__init__.py
@@ -101,11 +101,15 @@ def parse_year_from_id(vuln_id: str) -> int | None:
 
     first_component = components[0].lower()
 
-    if len(components) == 4 and first_component == "alaskernel":
-        return try_convert_year(components[2])
-
     if len(components) == 3 and first_component in {"cve", "alas", "elsa"}:
         return try_convert_year(components[1])
+
+    # there are cases in the amazon data that are considered "extras" and the vulnerability ID is augmented
+    # in a way that portrays the application scope. For instance, ALASRUBY3.0-2023-003 or ALASSELINUX-NG-2023-001.
+    # fore more information on the "extras" feature for amazon linux, see: https://aws.amazon.com/amazon-linux-2/faqs/#Amazon_Linux_Extras
+    if first_component.startswith("alas") and len(components) >= 3:
+        # note that we need to reference the compoents from the end since the ID may contain a dynamic number of hyphens.
+        return try_convert_year(components[-2])
 
     return None
 

--- a/tests/unit/store/test_scan_result.py
+++ b/tests/unit/store/test_scan_result.py
@@ -188,6 +188,7 @@ class TestFilterByYear:
                     # "ELSA-1999-1234", # note: cve 2021
                     # "ALAS-1999-1234", # note: cve 2021
                     # "ALASKERNEL-5.1-1999-1234", # note: cve 2021
+                    # "ALASKERNEL-1999-1234", # note: cve 2021
                 ],
                 2002,
                 True,
@@ -217,6 +218,7 @@ class TestFilterByYear:
                     # "ELSA-1999-1234", # note: cve 2021
                     # "ALAS-1999-1234", # note: cve 2021
                     # "ALASKERNEL-5.1-1999-1234", # note: cve 2021
+                    # "ALASKERNEL-1999-1234", # note: cve 2021
                 ],
                 2000,
                 True,
@@ -241,6 +243,7 @@ class TestFilterByYear:
                     # "ELSA-1999-1234",  # note: cve 2021
                     # "ALAS-1999-1234",  # note: cve 2021
                     # "ALASKERNEL-5.1-1999-1234", # note: cve 2021
+                    # "ALASKERNEL-1999-1234", # note: cve 2021
                 ],
                 1999,
                 True,
@@ -258,10 +261,10 @@ class TestFilterByYear:
                     "ELSA-1999-1234",  # note: cve 2021
                     "ALAS-1999-1234",  # note: cve 2021
                     "ALASKERNEL-5.1-1999-1234",  # note: cve 2021
+                    "ALASKERNEL-1999-1234",  # note: cve 2021
                     "ELSA-1998-0098",  # note: no cve
                     "ALAS-1998-0098",  # note: no cve
-                    # Invalid ID, but since we don't know how to get the year it's included
-                    "ALASKERNEL-1998-0098",  # note: no cve
+                    "ALASKERNEL-1998-0098",  # note: cve 2021
                     # ID above year limit
                     # "ELSA-2021-0001",  # note: cve 2000
                     # "ALAS-2021-0001",  # note: cve 2000
@@ -283,6 +286,7 @@ class TestFilterByYear:
                     "ELSA-1999-1234",  # note: cve 2021
                     "ALAS-1999-1234",  # note: cve 2021
                     "ALASKERNEL-5.1-1999-1234",  # note: cve 2021
+                    "ALASKERNEL-1999-1234",  # note: cve 2021
                     "ELSA-1998-0098",  # note: no cve
                     "ALAS-1998-0098",  # note: no cve
                     # Invalid ID, but since we don't know how to get the year it's included
@@ -309,7 +313,7 @@ class TestFilterByYear:
                     "ELSA-1999-1234",  # note: cve 2021
                     "ALAS-1999-1234",  # note: cve 2021
                     "ALASKERNEL-5.1-1999-1234",  # note: cve 2021
-                    # Invalid ID, but since we don't know how to get the year it's included
+                    "ALASKERNEL-1999-1234",  # note: cve 2021
                     "ALASKERNEL-1998-0098",  # note: no cve
                     # ID above year limit
                     # "CVE-2000-1",

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from yardstick import utils
+
+
+@pytest.mark.parametrize(
+    ("input", "expected_year"),
+    [
+        ("CVE-2016-2781", 2016),
+        ("CVE-1989-18276", None),
+        ("CVE-20222-18276", None),
+        ("ALAS-2019-1234", 2019),
+        ("ALASRUBY2.6-2023-006", 2023),
+        ("ALASSELINUX-NG-2023-001", 2023),
+        ("ALASKERNEL-5.4-2023-043", 2023),
+        ("ELSA-2023-6162", 2023),
+    ],
+)
+def test_parse_year_from_id(input, expected_year):
+    assert utils.parse_year_from_id(input) == expected_year


### PR DESCRIPTION
We lean on extracting the year from vulnerability IDs in order to apply a low-pass-like filter so that newer vulnerabilities can be excluded from consideration during analysis. This expands the rules around ALAS IDs to consider the "extras" packages, here's a snippet from vunnel logs to get the idea of what kind of IDs you can see now:
```
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASREDIS6-2024-009.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-001.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-002.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-003.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-004.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-005.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-006.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY2.6-2023-007.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-001.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-002.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-003.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-004.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-005.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-006.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASRUBY3.0-2023-007.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASSELINUX-NG-2023-001.html
[DEBUG] http GET https://alas.aws.amazon.com/AL2/ALASSQUID4-2023-001.html
```