### PR TITLE
Consider related vulnerability IDs in label comparison

### DIFF
--- a/src/yardstick/cli/explore/image_labels/label_selection_pane.py
+++ b/src/yardstick/cli/explore/image_labels/label_selection_pane.py
@@ -109,6 +109,7 @@ class LabelSelectionPane:
                 to_formatted_text(f"{i+1}. "),
                 to_formatted_text(entry.label.display, label_style),
                 to_formatted_text(f" [{entry.ID}]"),
+                to_formatted_text(f" {entry.vulnerability_id}"),
             ]
 
             result += [

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -226,6 +226,7 @@ def explore_labels(
     label_entries = store.labels.load_for_image(
         [scan_config.image, *lineage],
         year_max_limit=year_max_limit,
+        year_from_cve_only=derive_year_from_cve_only,
     )
 
     filter_spec = ""

--- a/src/yardstick/label.py
+++ b/src/yardstick/label.py
@@ -27,7 +27,7 @@ def find_labels_for_match(  # noqa: PLR0913, PLR0912, C901
     matched_label_entries: List[LabelEntry] = []
     for label_entry in label_entries:
         # this field must be matched to continue
-        if label_entry.vulnerability_id != match.vulnerability.id:
+        if not has_overlapping_vulnerability_id(label_entry, match):
             continue
 
         # this field must be matched to continue
@@ -78,6 +78,19 @@ def find_labels_for_match(  # noqa: PLR0913, PLR0912, C901
             # we should match on a minimum number of fields, otherwise a blank entry with a vuln ID will match, which is wrong
             matched_label_entries.append(label_entry)
     return matched_label_entries
+
+
+def has_overlapping_vulnerability_id(label_entry: LabelEntry, match: Match) -> bool:
+    left_ids = {label_entry.vulnerability_id, label_entry.effective_cve}
+    right_ids = {match.vulnerability.id, match.vulnerability.cve_id}
+
+    if "" in left_ids:
+        left_ids.remove("")
+
+    if "" in right_ids:
+        right_ids.remove("")
+
+    return bool(left_ids & right_ids)
 
 
 def _contains_as_value(o, target):

--- a/tests/unit/test_comparison.py
+++ b/tests/unit/test_comparison.py
@@ -73,6 +73,14 @@ def test_comparison_against_labels():
             package=package_libc_2,
             **common_label_options,
         ),
+        # do not have matches and already are covered with effective CVE... but the package mismatches
+        artifact.LabelEntry(
+            label=artifact.Label.TruePositive,
+            vulnerability_id="ELSA-2020-123567",
+            effective_cve="CVE-2019-18276",
+            package=package_libsystemd_25,
+            **common_label_options,
+        ),
     ]
 
     label_entries = [
@@ -121,6 +129,14 @@ def test_comparison_against_labels():
             package=package_libsystemd_25,
             **common_label_options,
         ),
+        # do not have matches and already are covered with effective CVE
+        artifact.LabelEntry(
+            label=artifact.Label.TruePositive,
+            vulnerability_id="ELSA-2020-123567",
+            effective_cve="CVE-2019-18276",
+            package=package_bash_5,
+            **common_label_options,
+        ),
     ]
 
     actual = comparison.AgainstLabels(
@@ -132,7 +148,7 @@ def test_comparison_against_labels():
     assert actual.summary.true_positives == len(expected_tp_matches)
     assert actual.summary.false_positives == len(expected_fp_matches)
     assert actual.summary.false_negatives == len(false_negative_label_entries)
-    assert actual.summary.f1_score == 0.5
+    assert actual.summary.f1_score == 0.4444444444444444
 
     assert set(actual.true_positive_matches) == set(expected_tp_matches)
     assert set(actual.false_positive_matches) == set(expected_fp_matches)


### PR DESCRIPTION
When pairing label entries with vulnerability matches we should ensure that we are considering both the primary vulnerability ID as well as any related IDs (such as effective CVE) such that we are making the broadest pairing possible. This is so that if we find an `ELSA` but not the `CVE` directly, and we have a true positive label for the `CVE`, then we wouldn't count that `CVE` as a false negative (and indeed should pair up the match and true positive label entry).

This additionally places the primary vulnerability ID in the `label explore` command's label pane.