### PR TITLE
feat: require complete and valid image ref on config parse

### DIFF
--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -79,8 +79,8 @@ class ScanMatrix:
         parsed, result = ScanMatrix.parse_oci_reference(image)
         if not parsed or not result:
             return False
-        host, path, repository, tag, digest = result
-        return all([host, path, repository, tag, digest])
+        host, _, repository, tag, digest = result
+        return all([host, repository, tag, digest])
 
     @staticmethod
     def parse_oci_reference(
@@ -111,10 +111,13 @@ class ScanMatrix:
         # Split the host and path part, path is between first / and end of path
         parts = host_and_path.split("/")
         if len(parts) < 1:
-            raise ValueError("Invalid OCI reference: missing repository")
+            return False, None
 
         host = parts[0]
         path = "/".join(parts[1:]) if len(parts) > 1 else ""
+        if not path:
+            if "." not in host and "localhost" not in host:
+                return False, None
 
         return True, (host, path, repository, tag, digest)
 

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -99,13 +99,13 @@ test_profile:
             True,
         ),
         (
-            "invalid: missing host",
-            "repo/image:latest@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            False,
+            "valid: missing tag is allowed but discouraged",
+            "registry.access.redhat.com/ubi8@sha256:68fecea0d255ee253acbf0c860eaebb7017ef5ef007c25bee9eeffd29ce85b29",
+            True,
         ),
         (
-            "invalid: missing tag",
-            "registry.example.com/repo/image@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            "invalid: missing host",
+            "repo/image:latest@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
             False,
         ),
         ("invalid: missing digest", "registry.example.com/repo/image:latest", False),
@@ -130,3 +130,65 @@ def test_is_valid_oci_reference(name, image, expected_valid):
     assert (
         result == expected_valid
     ), f"Test case {name}: Expected {expected_valid} but got {result} for image '{image}'"
+
+
+@pytest.mark.parametrize(
+    "image, expected_output",
+    [
+        (
+            "docker.io/anchore/test_images:some-tag@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            (
+                "docker.io",
+                "anchore",
+                "test_images",
+                "some-tag",
+                "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            ),
+        ),
+        # Localhost reference with path, repository, tag, and digest
+        (
+            "localhost/anchore/test_images:some-tag@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            (
+                "localhost",
+                "anchore",
+                "test_images",
+                "some-tag",
+                "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            ),
+        ),
+        # Localhost with port, path, repository, tag, and digest
+        (
+            "localhost:5000/anchore/test_images:some-tag@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            (
+                "localhost:5000",
+                "anchore",
+                "test_images",
+                "some-tag",
+                "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            ),
+        ),
+        # Missing digest
+        (
+            "docker.io/anchore/test_images:some-tag",
+            ("docker.io", "anchore", "test_images", "some-tag", ""),
+        ),
+        # Missing tag
+        (
+            "docker.io/anchore/test_images@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            (
+                "docker.io",
+                "anchore",
+                "test_images",
+                "",
+                "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+            ),
+        ),
+        # Only repository
+        ("test_images", ("", "", "test_images", "", "")),
+    ],
+)
+def test_parse_oci_reference(image, expected_output):
+    result = config.ScanMatrix.parse_oci_reference(image)
+    assert (
+        result == expected_output
+    ), f"Expected {expected_output} but got {result} for image '{image}'"

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -117,10 +117,15 @@ test_profile:
             False,
         ),
         ("invalid: missing repo and tag", "registry.example.com/", False),
-        ("invalid:missing digest", "registry.example.com/repo/image:stable", False),
+        ("invalid: missing digest", "registry.example.com/repo/image:stable", False),
         (
             "invalid: digest does not look like sha256",
             "registry.example.com/repo/image:latest@sha256:invaliddigest",
+            False,
+        ),
+        (
+            "invalid: bad sha256 (too short)",
+            "docker.io/alpine:3.2@sha256:ddac200f3ebc9902fb8cfcd599f41feb2151f1118929da21bcef57dc27697",
             False,
         ),
     ],

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -87,6 +87,11 @@ test_profile:
             "docker.io/vulhub/cve-2017-1000353:latest@sha256:da2a59314b9ccfb428a313a7f163adcef77a74a393b8ebadeca8223b8cea9797",
             True,
         ),
+        (
+            "valid: alpine",
+            "docker.io/alpine:3.2@sha256:ddac200f3ebc9902fb8cfcd599f41feb2151f1118929da21bcef57dc276975f9",
+            True,
+        ),
         # valid: localhost with port as repo host
         (
             "valid: localhost with port as repo host",


### PR DESCRIPTION
Because image references are used to compute paths to state relating to the scan of the image, it's critical that the image is always completely specified.

Note: I looked into using https://github.com/anchore/yardstick/blob/main/src/yardstick/artifact.py#L390 for this parsing, but that doesn't seem to be what the object is for.

## TODO

- [x] `docker.io/alpine:3.2@sha256:ddac200f3ebc9902fb8cfcd599f41feb2151f1118929da21bcef57dc276975f9` should be valid