### PR TITLE
Remove colr dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "requests<3.0.0,>=2.32.3",
     "GitPython<4.0.0,>=3.1.43",
     "rfc3339<7.0,>=6.2",
-    "Colr<1.0.0,>=0.9.1",
     "omitempty<1.0.0,>=0.1.1",
     "importlib-metadata<9.0.0,>=7.0.1",
     "mergedeep<2.0.0,>=1.3.4",

--- a/src/yardstick/cli/display.py
+++ b/src/yardstick/cli/display.py
@@ -2,7 +2,6 @@ import colorsys
 import json
 from typing import Any, Union
 
-from colr import color  # type: ignore[import]
 from tabulate import tabulate
 
 from yardstick import artifact, comparison
@@ -75,6 +74,14 @@ def matches(comp: comparison.ByMatch, details=True, summary=True, common=True):
 #############################################################################################################
 # For label comparisons
 
+def red(text: str) -> str:
+    return f"\033[91m{text}\033[0m"
+
+def rgb_ansi(r, g, b):
+    return f"\033[38;2;{r};{g};{b}m"
+
+def reset_ansi():
+    return "\033[0m"
 
 def get_section_rgb_tuple(index, sections):
     half_sections = int(sections / 2)
@@ -115,7 +122,7 @@ def format_value_red_green_spectrum(
     )
     color_rgb_tuple = get_section_rgb_tuple(index, sections)
 
-    formatted_value = color(f"{value:6.2f}", fore=color_rgb_tuple)
+    formatted_value =  f"{rgb_ansi(*color_rgb_tuple)}{value:6.2f}{reset_ansi()}"
 
     if value_ratio > 0.9:
         # bold
@@ -264,7 +271,7 @@ Each indeterminate match for each tool-image pair is logged above.""",
                 f1_score_str = (
                     "error!"
                     if lower == -1 or upper == -1
-                    else color(f"Impractical ({lower:0.2f}-{upper:0.2f})", fore="red")
+                    else red(f"Impractical ({lower:0.2f}-{upper:0.2f})")
                 )
             else:
                 f1_score_str = ""

--- a/uv.lock
+++ b/uv.lock
@@ -159,12 +159,6 @@ wheels = [
 ]
 
 [[package]]
-name = "colr"
-version = "0.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/a9/75bcc155e0bf57062e77974a5aea724123de3becd69fca6f8572127c09a2/Colr-0.9.1.tar.gz", hash = "sha256:8c15437eeb2ec8821c6df24b62946dfc6b79f69a1d84c1a6c131945a5ff4623c", size = 116430 }
-
-[[package]]
 name = "coverage"
 version = "7.6.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1077,11 +1071,10 @@ wheels = [
 
 [[package]]
 name = "yardstick"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "colr" },
     { name = "dataclass-wizard" },
     { name = "dataclasses-json" },
     { name = "gitpython" },
@@ -1125,7 +1118,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8,<9" },
-    { name = "colr", specifier = ">=0.9.1,<1.0.0" },
     { name = "dataclass-wizard", specifier = ">=0.30.1,<1.0.0" },
     { name = "dataclasses-json", specifier = ">=0.6.7,<1.0.0" },
     { name = "gitpython", specifier = ">=3.1.43,<4.0.0" },


### PR DESCRIPTION
This will stop functioning with python 3.13 due to an import, however, the lib appears to be unmaintained. We only use this for a small bit of functionality, so I've carved that out and removed the dependency altogether.