### PR TITLE
fix: update python constraint to support py3.13.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yardstick"
-requires-python = "<=3.13,>=3.11"
+requires-python = "<3.14,>=3.11"
 authors = [
     {name = "Alex Goodman", email = "alex.goodman@anchore.com"},
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.11, <=3.13"
+requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
     "python_full_version < '3.12'",
@@ -1071,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "yardstick"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
seeing some build failure as 

```
... requires a different Python: 3.13.1 not in '<=3.13,>=3.11'
```