### PR TITLE
feat: delimit between images in validate output

### DIFF
--- a/src/yardstick/cli/validate.py
+++ b/src/yardstick/cli/validate.py
@@ -12,15 +12,15 @@ from yardstick.validate import Gate, GateInputDescription
 
 
 class bcolors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
-    RESET = "\033[0m"
+    HEADER: str = "\033[95m"
+    OKBLUE: str = "\033[94m"
+    OKCYAN: str = "\033[96m"
+    OKGREEN: str = "\033[92m"
+    WARNING: str = "\033[93m"
+    FAIL: str = "\033[91m"
+    BOLD: str = "\033[1m"
+    UNDERLINE: str = "\033[4m"
+    RESET: str = "\033[0m"
 
 
 if not sys.stdout.isatty():
@@ -57,9 +57,7 @@ if not sys.stdout.isatty():
     is_flag=True,
     help="show label comparison results broken down by ecosystem",
 )
-@click.option(
-    "--verbose", "-v", "verbosity", count=True, help="show details of all comparisons"
-)
+@click.option("--verbose", "-v", "verbosity", count=True, help="show details of all comparisons")
 @click.option(
     "--result-set",
     "-r",
@@ -86,20 +84,14 @@ def validate(
 ):
     # TODO: don't artificially inflate logging; figure out what to print
     setup_logging(verbosity + 3)
-    if (
-        all_result_sets and result_sets and len(result_sets) > 0
-    ):  # default result set will be present anyway
-        raise ValueError(
-            f"cannot pass --all and -r / --result-set: {all_result_sets} {result_sets}"
-        )
+    if all_result_sets and result_sets and len(result_sets) > 0:  # default result set will be present anyway
+        raise ValueError(f"cannot pass --all and -r / --result-set: {all_result_sets} {result_sets}")
 
     if all_result_sets:
         result_sets = [r for r in cfg.result_sets.keys()]
 
     if not result_sets:
-        raise ValueError(
-            "must pass --result-set / -r at least once or --all to validate all result sets"
-        )
+        raise ValueError("must pass --result-set / -r at least once or --all to validate all result sets")
 
     # let's not load any more labels than we need to, base this off of the images we're validating
     if not images:
@@ -112,9 +104,7 @@ def validate(
         images = sorted(list(unique_images))
 
     click.echo("Loading label entries...", nl=False)
-    label_entries = store.labels.load_for_image(
-        images, year_max_limit=cfg.max_year_for_any_result_set(result_sets)
-    )
+    label_entries = store.labels.load_for_image(images, year_max_limit=cfg.max_year_for_any_result_set(result_sets))
     click.echo(f"done! {len(label_entries)} entries loaded")
 
     gates = []
@@ -124,9 +114,7 @@ def validate(
             if gate_config.max_year is None:
                 gate_config.max_year = cfg.default_max_year
 
-            click.echo(
-                f"{bcolors.HEADER}{bcolors.BOLD}Validating with {result_set!r}{bcolors.RESET}"
-            )
+            click.echo(f"{bcolors.HEADER}{bcolors.BOLD}Validating with {result_set!r}{bcolors.RESET}")
             new_gates = val.validate_result_set(
                 gate_config,
                 result_set,
@@ -136,8 +124,7 @@ def validate(
                 label_entries=label_entries,
             )
             for gate in new_gates:
-                show_results_used(gate.input_description)
-                show_delta_commentary(gate)
+                show_results_for_image(gate.input_description, gate)
 
             gates.extend(new_gates)
         click.echo()
@@ -146,12 +133,10 @@ def validate(
             click.echo(
                 f"{bcolors.HEADER}Breaking down label comparison by ecosystem performance...{bcolors.RESET}",
             )
-            results_by_image, label_entries, stats = (
-                yardstick.compare_results_against_labels_by_ecosystem(
-                    result_set=result_set,
-                    year_max_limit=cfg.max_year_for_result_set(result_set),
-                    label_entries=label_entries,
-                )
+            results_by_image, label_entries, stats = yardstick.compare_results_against_labels_by_ecosystem(
+                result_set=result_set,
+                year_max_limit=cfg.max_year_for_result_set(result_set),
+                label_entries=label_entries,
             )
             display.labels_by_ecosystem_comparison(
                 results_by_image,
@@ -172,9 +157,7 @@ def validate(
         click.echo(f"{bcolors.FAIL}{bcolors.BOLD}Quality gate FAILED{bcolors.RESET}")
         sys.exit(1)
     else:
-        click.echo(
-            f"{bcolors.OKGREEN}{bcolors.BOLD}Quality gate passed!{bcolors.RESET}"
-        )
+        click.echo(f"{bcolors.OKGREEN}{bcolors.BOLD}Quality gate passed!{bcolors.RESET}")
 
 
 def setup_logging(verbosity: int):
@@ -245,9 +228,7 @@ def show_delta_commentary(gate: Gate):
         return ansi_escape.sub("", line)
 
     # sort but don't consider ansi escape codes
-    all_rows = sorted(
-        all_rows, key=lambda x: escape_ansi(str(x[0] + x[1] + x[2] + x[3]))
-    )
+    all_rows = sorted(all_rows, key=lambda x: escape_ansi(str(x[0] + x[1] + x[2] + x[3])))
     click.echo("Match differences between tooling (with labels):")
     indent = "   "
     click.echo(
@@ -260,9 +241,7 @@ def show_delta_commentary(gate: Gate):
     )
 
 
-def show_results_used(input_description: GateInputDescription):
-    if not input_description:
-        return
+def show_results_for_image(input_description: GateInputDescription, gate: Gate):
     click.echo(f"   Results used for image {input_description.image}:")
     for idx, description in enumerate(input_description.configs):
         branch = "├──"
@@ -271,7 +250,8 @@ def show_results_used(input_description: GateInputDescription):
         label = " "
         if description.tool_label and len(description.tool_label) > 0:
             label = f" ({description.tool_label}) "
-        click.echo(
-            f"    {branch} {description.id} : {description.tool}{label} against {input_description.image}"
-        )
-    click.echo()
+        click.echo(f"    {branch} {description.id} : {description.tool}{label} against {input_description.image}")
+    if gate.deltas:
+        click.echo(f"Deltas for {input_description.image}:")
+        show_delta_commentary(gate)
+    click.echo("-" * 80)

--- a/uv.lock
+++ b/uv.lock
@@ -1071,7 +1071,7 @@ wheels = [
 
 [[package]]
 name = "yardstick"
-version = "0.12.1"
+version = "0.12.1.post2+2fb68de"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Otherwise, it's easy for an operator to investigate the wrong image when investigating a quality gate failure.

Example of new output:

```

   Results used for image docker.io/anchore/test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1:
    ├── 86723334-feee-4a64-8d9f-5878bfb3ee34 : grype[candidate]@path:../../+import-db=db.tar.gz (candidate)  against docker.io/anchore/test_images@sha256:c8d66
4b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1
    └── 4b769e08-5b30-413f-a2b0-5226e03f3dd1 : grype[reference]@v0.86.1 (reference)  against docker.io/anchore/test_images@sha256:c8d664b0e728d52f57eeb98ed1899
c16d3b265f02ddfb41303d7a16c31e0b0f1
Deltas for docker.io/anchore/test_images@sha256:c8d664b0e728d52f57eeb98ed1899c16d3b265f02ddfb41303d7a16c31e0b0f1:
Match differences between tooling (with labels):
   TOOL PARTITION                                         PACKAGE                                             VULNERABILITY   LABEL      COMMENTARY
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  jcl-over-slf4j@0:1.7.25-4.module+el8+5161+5cac467c  CVE-2018-14040  (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  jcl-over-slf4j@0:1.7.25-4.module+el8+5161+5cac467c  CVE-2019-16943  (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  jcl-over-slf4j@0:1.7.25-4.module+el8+5161+5cac467c  CVE-2020-1695   (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  jcl-over-slf4j@0:1.7.25-4.module+el8+5161+5cac467c  CVE-2020-36518  (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  slf4j@0:1.7.25-4.module+el8+5161+5cac467c           CVE-2018-14040  (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  slf4j@0:1.7.25-4.module+el8+5161+5cac467c           CVE-2019-16943  (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  slf4j@0:1.7.25-4.module+el8+5161+5cac467c           CVE-2020-1695   (unknown)
   grype[candidate]@path:../../+import-db=db.tar.gz ONLY  slf4j@0:1.7.25-4.module+el8+5161+5cac467c           CVE-2020-36518  (unknown)

--------------------------------------------------------------------------------
   Results used for image docker.io/anchore/test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b:
    ├── c14cbb69-43e2-479b-a509-1273ec83b38c : grype[candidate]@path:../../+import-db=db.tar.gz (candidate)  against docker.io/anchore/test_images@sha256:524ff
8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b
    └── 1a02b242-db41-48dc-9c18-82f02054f1af : grype[reference]@v0.86.1 (reference)  against docker.io/anchore/test_images@sha256:524ff8a75f21fd886ec7ed8238776
6df386671e8b77e898d05786118d5b7880b
Deltas for docker.io/anchore/test_images@sha256:524ff8a75f21fd886ec7ed82387766df386671e8b77e898d05786118d5b7880b:
Match differences between tooling (with labels):
   TOOL PARTITION                 PACKAGE                                             VULNERABILITY   LABEL          COMMENTARY
   grype[reference]@v0.86.1 ONLY  php-cli@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-cli@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-cli@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-common@7.4.30-1.module_el8.7.0+1190+d11b935a    CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-common@7.4.30-1.module_el8.7.0+1190+d11b935a    CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-common@7.4.30-1.module_el8.7.0+1190+d11b935a    CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-fpm@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-fpm@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-fpm@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-json@7.4.30-1.module_el8.7.0+1190+d11b935a      CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-json@7.4.30-1.module_el8.7.0+1190+d11b935a      CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-json@7.4.30-1.module_el8.7.0+1190+d11b935a      CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-mbstring@7.4.30-1.module_el8.7.0+1190+d11b935a  CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-mbstring@7.4.30-1.module_el8.7.0+1190+d11b935a  CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-mbstring@7.4.30-1.module_el8.7.0+1190+d11b935a  CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-opcache@7.4.30-1.module_el8.7.0+1190+d11b935a   CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-opcache@7.4.30-1.module_el8.7.0+1190+d11b935a   CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-opcache@7.4.30-1.module_el8.7.0+1190+d11b935a   CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-pdo@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-pdo@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-pdo@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php-xml@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-xml@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php-xml@7.4.30-1.module_el8.7.0+1190+d11b935a       CVE-2021-32610  TruePositive   (this is a new FN 😱)
   grype[reference]@v0.86.1 ONLY  php@7.4.30-1.module_el8.7.0+1190+d11b935a           CVE-2021-21707  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php@7.4.30-1.module_el8.7.0+1190+d11b935a           CVE-2021-21708  FalsePositive  (got rid of a former FP 🙌)
   grype[reference]@v0.86.1 ONLY  php@7.4.30-1.module_el8.7.0+1190+d11b935a           CVE-2021-32610  TruePositive   (this is a new FN 😱)

--------------------------------------------------------------------------------
   Results used for image docker.io/anchore/test_images@sha256:fc6f7a37d7e320f6ff3643d4ec9a208adb1462cd16027f045b56563e12bb0461:
    ├── fba9c2d8-dba1-46cb-ac6f-e9ff4264d93e : grype[candidate]@path:../../+import-db=db.tar.gz (candidate)  against docker.io/anchore/test_images@sha256:fc6f7
a37d7e320f6ff3643d4ec9a208adb1462cd16027f045b56563e12bb0461
    └── 864b4b43-5137-4192-a2ef-eb6a266b14c7 : grype[reference]@v0.86.1 (reference)  against docker.io/anchore/test_images@sha256:fc6f7a37d7e320f6ff3643d4ec9a2
08adb1462cd16027f045b56563e12bb0461
--------------------------------------------------------------------------------

```