### PR TITLE
chore: configure and run ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,12 @@ repos:
         pass_filenames: false
         language: system
 
+      - id: format
+        name: format
+        entry: make format
+        pass_filenames: false
+        language: system
+
       - id: mypy
         name: mypy
         entry: make check-types

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ lint:  ## Show linting issues (ruff)
 lint-fix:  ## Fix linting issues (ruff)
 	$(ENV) ruff check src --fix
 
+format: ## Format code (ruff format)
+	$(ENV) ruff format src tests
+
 .PHONY: check-types
 check-types:  ## Run type checks (mypy)
 	$(ENV) mypy --config-file ./pyproject.toml src/yardstick

--- a/src/yardstick/arrange.py
+++ b/src/yardstick/arrange.py
@@ -7,9 +7,7 @@ from yardstick import artifact
 def packages_by_vulnerability(
     matches: List[artifact.Match],
 ) -> Dict[artifact.Vulnerability, Set[artifact.Package]]:
-    result: Dict[artifact.Vulnerability, Set[artifact.Package]] = {
-        m.vulnerability: set() for m in matches
-    }
+    result: Dict[artifact.Vulnerability, Set[artifact.Package]] = {m.vulnerability: set() for m in matches}
     for match in matches:
         result[match.vulnerability].add(match.package)
     return result

--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -171,7 +171,7 @@ class ScanConfiguration:
 
     def __str__(self):
         s = f"""\
-image:\t\t{self.image_repo}{':'+self.image_tag if self.image_tag else ''}@{self.image_digest}
+image:\t\t{self.image_repo}{":" + self.image_tag if self.image_tag else ""}@{self.image_digest}
 tool:\t{self.tool}"""
         if self.timestamp:
             s += f"\ntimestamp:\t{self.timestamp}"
@@ -324,11 +324,7 @@ class Match:
         if self.package.version != other.package.version:
             return self.package.version < other.package.version
 
-        if (
-            self.config
-            and other.config
-            and self.package.version != other.package.version
-        ):
+        if self.config and other.config and self.package.version != other.package.version:
             return self.package.version < other.package.version
         return False
 
@@ -442,9 +438,7 @@ class LabelEntry:
     image: ImageSpecifier | None = None  # image specifier
     note: str | None = None  # a general comment field (optional)
     source: str | None = None  # e.g. manually added, import, etc. (optional)
-    effective_cve: str | None = (
-        None  # the CVE the vulnerability ID matches to (optional)
-    )
+    effective_cve: str | None = None  # the CVE the vulnerability ID matches to (optional)
     user: str | None = None  # the user that added this label (optional)
     package: Package | None = None  # package name/version
     fullentry_fields: list[str] = field(

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -20,9 +20,7 @@ class Timer:
 
 def run_scan(
     config: artifact.ScanConfiguration,
-    tool: Optional[
-        Union[vulnerability_scanner.VulnerabilityScanner, sbom_generator.SBOMGenerator]
-    ] = None,
+    tool: Optional[Union[vulnerability_scanner.VulnerabilityScanner, sbom_generator.SBOMGenerator]] = None,
     reinstall: bool = False,
     **kwargs,
 ) -> Tuple[artifact.ScanResult, str]:
@@ -151,7 +149,7 @@ def result_set(  # noqa: C901, PLR0912
     result_set_obj = artifact.ResultSet(name=result_set)
     total = len(scan_requests)
     for idx, scan_request in enumerate(scan_requests):
-        logging.info(f"capturing data for request {idx+1} of {total}")
+        logging.info(f"capturing data for request {idx + 1} of {total}")
         producer_data_path = None
         if scan_request.takes:
             producer = result_set_obj.provider(

--- a/src/yardstick/cli/config.py
+++ b/src/yardstick/cli/config.py
@@ -66,22 +66,14 @@ class ScanMatrix:
             else:
                 images += [image]
         self.images = images
-        invalid = [
-            image for image in images if not ScanMatrix.is_valid_oci_reference(image)
-        ]
+        invalid = [image for image in images if not ScanMatrix.is_valid_oci_reference(image)]
         if invalid:
-            raise ValueError(
-                f"all images must be complete OCI references, but {' '.join(invalid)} are not"
-            )
+            raise ValueError(f"all images must be complete OCI references, but {' '.join(invalid)} are not")
 
     @staticmethod
     def is_valid_oci_reference(image: str) -> bool:
         host, _, repository, _, digest = ScanMatrix.parse_oci_reference(image)
-        return (
-            all([host, repository, digest])
-            and bool(ScanMatrix.DIGEST_REGEX.match(digest or ""))
-            and ("." in host or "localhost" in host)
-        )
+        return all([host, repository, digest]) and bool(ScanMatrix.DIGEST_REGEX.match(digest or "")) and ("." in host or "localhost" in host)
 
     @staticmethod
     def parse_oci_reference(image: str) -> tuple[str, str, str, str, str]:
@@ -247,9 +239,7 @@ def _load_paths(
 
 def _load(path: str) -> Application:
     with open(path, encoding="utf-8") as f:
-        app_object = (
-            yaml.load(f.read(), yaml.SafeLoader) or {}
-        )  # noqa: S506 (since our loader is using the safe loader)
+        app_object = yaml.load(f.read(), yaml.SafeLoader) or {}  # noqa: S506 (since our loader is using the safe loader)
         # we need a full default application config first then merge the loaded config on top.
         # Why? dataclass_wizard.fromdict() will create instances from the dataclass default
         # and NOT the field definition from the container. So it is possible to specify a

--- a/src/yardstick/cli/display.py
+++ b/src/yardstick/cli/display.py
@@ -74,14 +74,18 @@ def matches(comp: comparison.ByMatch, details=True, summary=True, common=True):
 #############################################################################################################
 # For label comparisons
 
+
 def red(text: str) -> str:
     return f"\033[91m{text}\033[0m"
+
 
 def rgb_ansi(r, g, b):
     return f"\033[38;2;{r};{g};{b}m"
 
+
 def reset_ansi():
     return "\033[0m"
+
 
 def get_section_rgb_tuple(index, sections):
     half_sections = int(sections / 2)
@@ -90,9 +94,7 @@ def get_section_rgb_tuple(index, sections):
             [(0, float(x) / float(half_sections - 1), 1) for x in range(half_sections)],
         ),
     )
-    green_hsv_tuples = [
-        (0.33, float(x) / float(half_sections - 1), 1) for x in range(half_sections)
-    ]
+    green_hsv_tuples = [(0.33, float(x) / float(half_sections - 1), 1) for x in range(half_sections)]
     spectrum = red_hsv_tuples + green_hsv_tuples
     values = [colorsys.hsv_to_rgb(*x) for x in spectrum][index]
     return values[0] * 255, values[1] * 255, values[2] * 255
@@ -122,7 +124,7 @@ def format_value_red_green_spectrum(
     )
     color_rgb_tuple = get_section_rgb_tuple(index, sections)
 
-    formatted_value =  f"{rgb_ansi(*color_rgb_tuple)}{value:6.2f}{reset_ansi()}"
+    formatted_value = f"{rgb_ansi(*color_rgb_tuple)}{value:6.2f}{reset_ansi()}"
 
     if value_ratio > 0.9:
         # bold
@@ -258,21 +260,13 @@ Each indeterminate match for each tool-image pair is logged above.""",
                     tool,
                     (-1, -1),
                 )
-                f1_score_str = (
-                    "error!"
-                    if lower == -1 or upper == -1
-                    else f"{format_value_red_green_spectrum(f1_score)} ({lower:0.2f}-{upper:0.2f})"
-                )
+                f1_score_str = "error!" if lower == -1 or upper == -1 else f"{format_value_red_green_spectrum(f1_score)} ({lower:0.2f}-{upper:0.2f})"
             elif f1_score and f1_score < 0:
                 lower, upper = stats_by_image_tool_pair.f1_score_ranges[image].get(
                     tool,
                     (-1, -1),
                 )
-                f1_score_str = (
-                    "error!"
-                    if lower == -1 or upper == -1
-                    else red(f"Impractical ({lower:0.2f}-{upper:0.2f})")
-                )
+                f1_score_str = "error!" if lower == -1 or upper == -1 else red(f"Impractical ({lower:0.2f}-{upper:0.2f})")
             else:
                 f1_score_str = ""
             row.append(f1_score_str)
@@ -313,7 +307,8 @@ def label_comparison_json(
 
         if show_fns:
             more["fns"] = [
-                label.to_dict() for label in comp.false_negative_label_entries  # type: ignore[attr-defined]
+                label.to_dict()  # type: ignore[attr-defined]
+                for label in comp.false_negative_label_entries
             ]
 
         if show_indeterminates:
@@ -323,10 +318,7 @@ def label_comparison_json(
                     {
                         "match": match.to_dict(),  # type: ignore[attr-defined]
                         "label_set": sorted(
-                            [
-                                label.display
-                                for label in set(comp.labels_by_match.get(match.ID, []))
-                            ],
+                            [label.display for label in set(comp.labels_by_match.get(match.ID, []))],
                         ),
                         "labels": [
                             label.to_dict()  # type: ignore[attr-defined]
@@ -341,20 +333,12 @@ def label_comparison_json(
                 "tool": tool,
                 "stats": {
                     "f1_score": stats_by_image_tool_pair.f1_scores[image][tool],
-                    "f1_score_range": stats_by_image_tool_pair.f1_score_ranges[image][
-                        tool
-                    ],
+                    "f1_score_range": stats_by_image_tool_pair.f1_score_ranges[image][tool],
                     "fn": stats_by_image_tool_pair.false_negatives[image][tool],
                     "tp": stats_by_image_tool_pair.true_positives[image][tool],
                     "fp": stats_by_image_tool_pair.false_positives[image][tool],
-                    "indeterminate": stats_by_image_tool_pair.indeterminate[image][
-                        tool
-                    ],
-                    "indeterminate_percent": stats_by_image_tool_pair.indeterminate_percent[
-                        image
-                    ][
-                        tool
-                    ],
+                    "indeterminate": stats_by_image_tool_pair.indeterminate[image][tool],
+                    "indeterminate_percent": stats_by_image_tool_pair.indeterminate_percent[image][tool],
                 },
                 **more,
             },

--- a/src/yardstick/cli/explore/image_labels/label_manager.py
+++ b/src/yardstick/cli/explore/image_labels/label_manager.py
@@ -113,9 +113,7 @@ class LabelManager:
         self.filter_text = None
         # we should filter down the set of label entries that we have to only those which match with this image. This
         # is a performance enhancement to prevent matching an ALL labels for all images on every UI action.
-        self.label_entries: List[artifact.LabelEntry] = (
-            self._keep_only_matched_label_entries(label_entries, lineage)
-        )
+        self.label_entries: List[artifact.LabelEntry] = self._keep_only_matched_label_entries(label_entries, lineage)
         self.match_select_entries_invalidated = True
         self._last_match_select_entries: List[MatchSelectEntry] = []
         self.deleted_label_entries: List[artifact.LabelEntry] = []
@@ -222,9 +220,7 @@ class LabelManager:
         self,
         label_entry_id: str,
     ) -> Optional[artifact.LabelEntry]:
-        label_entries = [
-            label for label in self.label_entries if label_entry_id == label.ID
-        ]
+        label_entries = [label for label in self.label_entries if label_entry_id == label.ID]
         if len(label_entries) > 1:
             raise RuntimeError
 

--- a/src/yardstick/cli/explore/image_labels/label_selection_pane.py
+++ b/src/yardstick/cli/explore/image_labels/label_selection_pane.py
@@ -91,11 +91,7 @@ class LabelSelectionPane:
                 result.append([("[SetCursorPosition]", "")])
 
             note = entry.note
-            formatted_note = (
-                to_formatted_text("[no note provided]", style="italic")
-                if not note
-                else to_formatted_text(note)
-            )
+            formatted_note = to_formatted_text("[no note provided]", style="italic") if not note else to_formatted_text(note)
 
             label_style = ""
             if entry.label == artifact.Label.TruePositive:
@@ -106,7 +102,7 @@ class LabelSelectionPane:
                 label_style = "#888888"
 
             result += [
-                to_formatted_text(f"{i+1}. "),
+                to_formatted_text(f"{i + 1}. "),
                 to_formatted_text(entry.label.display, label_style),
                 to_formatted_text(f" [{entry.ID}]"),
                 to_formatted_text(f" {entry.vulnerability_id}"),

--- a/src/yardstick/cli/explore/image_labels/result_selection_pane.py
+++ b/src/yardstick/cli/explore/image_labels/result_selection_pane.py
@@ -195,10 +195,7 @@ class ResultSelectionPane:
         else:
 
             def fetch_in_background():
-                if (
-                    self.get_selected_entry().match.vulnerability.id
-                    == entry.match.vulnerability.id
-                ):
+                if self.get_selected_entry().match.vulnerability.id == entry.match.vulnerability.id:
                     self.cve_descriptions.get(entry.match.vulnerability.id)
                     get_app().invalidate()
 

--- a/src/yardstick/cli/explore/image_labels/text_area.py
+++ b/src/yardstick/cli/explore/image_labels/text_area.py
@@ -142,9 +142,7 @@ class TextArea:
         )
 
         if multiline:
-            _right_margins: list[Margin] = (
-                [ScrollbarMargin(display_arrows=False)] if scrollbar else []
-            )
+            _right_margins: list[Margin] = [ScrollbarMargin(display_arrows=False)] if scrollbar else []
 
             if right_margins:
                 _right_margins = right_margins + _right_margins

--- a/src/yardstick/cli/explore/result.py
+++ b/src/yardstick/cli/explore/result.py
@@ -43,13 +43,9 @@ class MatchCollection:
         if not self.result.matches:
             raise ValueError("no matches provided")
 
-        self.match_display_text_by_id = {
-            m.ID: display_match(m) for m in self.result.matches
-        }
+        self.match_display_text_by_id = {m.ID: display_match(m) for m in self.result.matches}
         self.match_by_id = {m.ID: m for m in self.result.matches}
-        self.match_id_by_display_text = {
-            v: k for k, v in self.match_display_text_by_id.items()
-        }
+        self.match_id_by_display_text = {v: k for k, v in self.match_display_text_by_id.items()}
 
     def has_display_text(self, text):
         return text in self.match_display_text_by_id.values()
@@ -139,9 +135,7 @@ class Executor(Completer):
                 "<b>match</b> <i>vuln</i>=str <i>package</i>=str <i>id</i>=str",
             ),
         }
-        self.command_descriptions: Dict[str, Optional[str]] = {
-            cmd: fn.__doc__ for cmd, fn in self.commands.items()
-        }
+        self.command_descriptions: Dict[str, Optional[str]] = {cmd: fn.__doc__ for cmd, fn in self.commands.items()}
 
     def get_completions(self, document: Document, complete_event: CompleteEvent):
         text = document.text.lower()
@@ -179,10 +173,7 @@ class Executor(Completer):
         if text:
             text = text.lstrip("list").strip()
 
-        matches = [
-            f"{num+1!s:3} | " + display_match(match)
-            for num, match in enumerate(sorted(self.matches.get_matches(text)))
-        ]
+        matches = [f"{num + 1!s:3} | " + display_match(match) for num, match in enumerate(sorted(self.matches.get_matches(text)))]
         print_formatted_text("\n".join(matches))
 
     def help(self, _: Optional[str] = None):  # noqa: A003

--- a/src/yardstick/cli/label.py
+++ b/src/yardstick/cli/label.py
@@ -95,9 +95,7 @@ def compare_results_against_labels(  # noqa: PLR0913
 @click.option("--summarize", "-s", is_flag=True, help="summarize each entry")
 @click.pass_obj
 def list_labels(_: config.Application, image: str, summarize: bool):
-    display_label_entries = (
-        store.labels.load_for_image(image) if image else store.labels.load_all()
-    )
+    display_label_entries = store.labels.load_for_image(image) if image else store.labels.load_all()
 
     for entry in display_label_entries:
         if summarize:

--- a/src/yardstick/comparison.py
+++ b/src/yardstick/comparison.py
@@ -86,8 +86,7 @@ class AgainstLabels:
         self.false_negative_label_entries = {
             label
             for label in self.label_entries
-            if label_entry_matches_image_lineage(label, result.config.image, lineage)
-            and label.label == Label.TruePositive
+            if label_entry_matches_image_lineage(label, result.config.image, lineage) and label.label == Label.TruePositive
         }
         self.true_positive_matches = []
         self.false_positive_matches = []
@@ -116,9 +115,7 @@ class AgainstLabels:
             self.false_negative_label_entries -= set(label_entries)
 
             self.label_entries_by_match[match.ID] = label_entries
-            self.labels_by_match[match.ID] = [
-                label_entry.label for label_entry in label_entries
-            ]
+            self.labels_by_match[match.ID] = [label_entry.label for label_entry in label_entries]
             labels_for_match = self.labels_by_match[match.ID]
             label_set = set(labels_for_match)
 
@@ -143,9 +140,7 @@ class AgainstLabels:
         # let's do one more pass regarding FNs. Since this is calculated based on the label entries we have,
         # and there may be multiple ways to represent the same vuln (ELSA-* and CVE-*), we need to ensure that
         # we remove any FNs that are actually TPs, but represented differently. This involves some guess work.
-        self.false_negative_label_entries = prune_represented_fns(
-            self.false_negative_label_entries, matched_true_positive_label_entries
-        )
+        self.false_negative_label_entries = prune_represented_fns(self.false_negative_label_entries, matched_true_positive_label_entries)
 
         self.summary = LabelComparisonSummary(result=result, comparison=self)
 
@@ -173,7 +168,6 @@ def prune_represented_fns(
 
 
 def has_overlapping_vulnerability_id(tp: LabelEntry, fn: LabelEntry) -> bool:
-
     left_ids = {tp.vulnerability_id, tp.effective_cve}
     right_ids = {fn.vulnerability_id, fn.effective_cve}
 
@@ -222,9 +216,7 @@ class LabelComparisonSummary:
 
         self.total = len(result.matches)
         self.indeterminate = len(comparison.matches_with_indeterminate_labels)
-        self.indeterminate_percent = (
-            utils.safe_div(self.indeterminate, self.total) * 100
-        )
+        self.indeterminate_percent = utils.safe_div(self.indeterminate, self.total) * 100
         self.true_positives = len(comparison.true_positive_matches)
         self.false_positives = len(comparison.false_positive_matches)
         self.false_negatives = len(comparison.false_negative_label_entries)
@@ -245,9 +237,7 @@ class LabelComparisonSummary:
             self.false_negatives,
         )
 
-        self.f1_score_is_practicable = (
-            self.f1_score_upper_confidence - self.f1_score_lower_confidence
-        ) <= 0.1  # is less than 10% variance
+        self.f1_score_is_practicable = (self.f1_score_upper_confidence - self.f1_score_lower_confidence) <= 0.1  # is less than 10% variance
 
     def __str__(self):
         lines = []
@@ -274,8 +264,7 @@ class LabelComparisonSummary:
         ]
 
         lines.append(
-            indent
-            + tabulate(results_table, tablefmt="plain").replace("\n", "\n" + indent),
+            indent + tabulate(results_table, tablefmt="plain").replace("\n", "\n" + indent),
         )
 
         lines.append(f"F1 score        : {self.f1_score:0.2f}       {usable}")
@@ -321,11 +310,7 @@ class ByPreservedMatch:
         # what set of matches are unique to each result?
         self.unique = {}
         for result in self.results:
-            other_sets = [
-                matches
-                for res_id, matches in self.match_set.items()
-                if res_id != result.ID
-            ]
+            other_sets = [matches for res_id, matches in self.match_set.items() if res_id != result.ID]
             self.unique[result.ID] = self.match_set[result.ID].difference(*other_sets)
 
         # what set of matches were discovered across all results? Keep track of each result that matches
@@ -394,11 +379,7 @@ class ByMatch:
         # what set of matches are unique to each result?
         self.unique = {}
         for result in self.results:
-            other_sets = [
-                matches
-                for res_id, matches in self.match_set.items()
-                if res_id != result.ID
-            ]
+            other_sets = [matches for res_id, matches in self.match_set.items() if res_id != result.ID]
             self.unique[result.ID] = self.match_set[result.ID].difference(*other_sets)
 
         self.summary = RelativeComparisonSummary(comparison=self, results=self.results)
@@ -428,9 +409,7 @@ class ByVulnerability:
         self.vulnerability_set_by_result_id = {}
         self.vulnerabilities = {}
         for result in self.results:
-            self.vulnerabilities[result.ID] = [
-                m.vulnerability.id for m in result.matches
-            ]
+            self.vulnerabilities[result.ID] = [m.vulnerability.id for m in result.matches]
             self.vulnerability_set_by_result_id[result.ID] = set(
                 self.vulnerabilities[result.ID],
             )
@@ -441,14 +420,8 @@ class ByVulnerability:
         # what set of vulnerabilities are unique to each result?
         self.unique = {}
         for result in self.results:
-            other_sets = [
-                vulnerabilities
-                for res_id, vulnerabilities in self.vulnerability_set_by_result_id.items()
-                if res_id != result.ID
-            ]
-            self.unique[result.ID] = self.vulnerability_set_by_result_id[
-                result.ID
-            ].difference(*other_sets)
+            other_sets = [vulnerabilities for res_id, vulnerabilities in self.vulnerability_set_by_result_id.items() if res_id != result.ID]
+            self.unique[result.ID] = self.vulnerability_set_by_result_id[result.ID].difference(*other_sets)
 
 
 # ByPackage looks solely at at matches package info for comparison. This alone isn't an accurate comparison,
@@ -481,14 +454,8 @@ class ByPackage:
         # what set of packages are unique to each result?
         self.unique = {}
         for result in self.results:
-            other_sets = [
-                packages
-                for res_id, packages in self.package_set_by_result_id.items()
-                if res_id != result.ID
-            ]
-            self.unique[result.ID] = self.package_set_by_result_id[
-                result.ID
-            ].difference(*other_sets)
+            other_sets = [packages for res_id, packages in self.package_set_by_result_id.items() if res_id != result.ID]
+            self.unique[result.ID] = self.package_set_by_result_id[result.ID].difference(*other_sets)
 
 
 @dataclass_json
@@ -540,13 +507,10 @@ class ComponentSummary:
         # why? because the common count is a set, so we cannot use non-set counts for the two data groups.
         jaccard_similarity = utils.safe_div(
             self.deduplicated_common_count,
-            sum(self.deduplicated_total_count.values())
-            - self.deduplicated_common_count,
+            sum(self.deduplicated_total_count.values()) - self.deduplicated_common_count,
         )
         # now we can easily compute the dice similarity...
-        self.dice_similarity_coefficient = (2 * jaccard_similarity) / (
-            jaccard_similarity + 1
-        )
+        self.dice_similarity_coefficient = (2 * jaccard_similarity) / (jaccard_similarity + 1)
 
 
 @dataclass_json
@@ -619,9 +583,7 @@ class RelativeComparisonSummary:
             )
 
         lines.append(
-            indent
-            + tabulate(results_table, tablefmt="plain").replace("\n", "\n" + indent)
-            + "\n",
+            indent + tabulate(results_table, tablefmt="plain").replace("\n", "\n" + indent) + "\n",
         )
 
         lines.append("Comparison Results (deduplicated): ")
@@ -654,9 +616,7 @@ class RelativeComparisonSummary:
             )
 
         lines.append(
-            indent
-            + tabulate(table, tablefmt="plain").replace("\n", "\n" + indent)
-            + "\n",
+            indent + tabulate(table, tablefmt="plain").replace("\n", "\n" + indent) + "\n",
         )
 
         lines.append(
@@ -753,10 +713,7 @@ class ImageToolLabelStats:
             else:
                 f1_scores[image][tool] = -1
 
-            if (
-                comp.summary.f1_score_lower_confidence != 0
-                and comp.summary.f1_score_upper_confidence != 0
-            ):
+            if comp.summary.f1_score_lower_confidence != 0 and comp.summary.f1_score_upper_confidence != 0:
                 f1_score_ranges[image][tool] = (
                     comp.summary.f1_score_lower_confidence,
                     comp.summary.f1_score_upper_confidence,
@@ -766,9 +723,7 @@ class ImageToolLabelStats:
             true_positives[image][tool] = comp.summary.true_positives
             false_positives[image][tool] = comp.summary.false_positives
             indeterminate[image][tool] = comp.summary.indeterminate
-            indeterminate_percent[image][tool] = (
-                utils.safe_div(comp.summary.indeterminate, comp.summary.total) * 100.0
-            )
+            indeterminate_percent[image][tool] = utils.safe_div(comp.summary.indeterminate, comp.summary.total) * 100.0
 
         return ImageToolLabelStats(
             configs=configs,
@@ -886,8 +841,7 @@ class ToolLabelStatsByEcosystem:
             for e in ecosystems:
                 stats.precision_by_tool_by_ecosystem[tool][e] = utils.safe_div(
                     stats.tps_by_tool_by_ecosystem[tool][e],
-                    stats.tps_by_tool_by_ecosystem[tool][e]
-                    + stats.fps_by_tool_by_ecosystem[tool][e],
+                    stats.tps_by_tool_by_ecosystem[tool][e] + stats.fps_by_tool_by_ecosystem[tool][e],
                 )
 
         return stats

--- a/src/yardstick/label.py
+++ b/src/yardstick/label.py
@@ -120,9 +120,7 @@ def merge_label_entries(
     new_and_modified_entries = new_and_modified_entries[:]
 
     # keep list indexes by label entry IDs
-    new_and_modified_id_idx = {
-        le.ID: idx for idx, le in enumerate(new_and_modified_entries)
-    }
+    new_and_modified_id_idx = {le.ID: idx for idx, le in enumerate(new_and_modified_entries)}
 
     # step 1: take potentially mutated entries and overwrite the original entries
     for original_idx, _ in enumerate(original_entries):
@@ -142,9 +140,7 @@ def merge_label_entries(
 
     # step 4: remove all ids which are explicitly deleted
     if deleted_ids:
-        original_entries = [
-            entry for entry in original_entries if entry.ID not in deleted_ids
-        ]
+        original_entries = [entry for entry in original_entries if entry.ID not in deleted_ids]
 
     # add the new elements to the final result
     return original_entries + new_entries

--- a/src/yardstick/store/labels.py
+++ b/src/yardstick/store/labels.py
@@ -172,9 +172,7 @@ def load_all(
 
     label_entries: list[artifact.LabelEntry] = []
     files = set(
-        list(glob.glob(f"{root_path}/**/**/*.json"))
-        + list(glob.glob(f"{root_path}/**/*.json"))
-        + list(glob.glob(f"{root_path}/*.json")),
+        list(glob.glob(f"{root_path}/**/**/*.json")) + list(glob.glob(f"{root_path}/**/*.json")) + list(glob.glob(f"{root_path}/*.json")),
     )
     for file in files:
         filepath = remove_prefix(file, root_path + "/")

--- a/src/yardstick/store/result_set.py
+++ b/src/yardstick/store/result_set.py
@@ -62,11 +62,7 @@ def load_scan_results(
 
     result_set = load(name, store_root=store_root)
 
-    descriptions = [
-        result_state.config.path
-        for result_state in result_set.state
-        if result_state.config
-    ]
+    descriptions = [result_state.config.path for result_state in result_set.state if result_state.config]
     return scan_result.load_by_descriptions(
         descriptions,
         year_max_limit=year_max_limit,

--- a/src/yardstick/tool/grype.py
+++ b/src/yardstick/tool/grype.py
@@ -323,9 +323,7 @@ class Grype(VulnerabilityScanner):
     def env(self, override=None):
         env = os.environ.copy()
         env["GRYPE_CHECK_FOR_APP_UPDATE"] = "false"
-        env["GRYPE_DB_VALIDATE_AGE"] = (
-            "false"  # if we are using a local DB, we don't want to validate it (but we should be consistent all the time)
-        )
+        env["GRYPE_DB_VALIDATE_AGE"] = "false"  # if we are using a local DB, we don't want to validate it (but we should be consistent all the time)
         env["GRYPE_DB_AUTO_UPDATE"] = "false"
         env["GRYPE_DB_CACHE_DIR"] = self.db_root
         if self._env:
@@ -470,9 +468,7 @@ def handle_zstd_archive(archive_path: str) -> str:
             hasher = xxhash.xxh64()
             with tar.extractfile(db_member) as db_file:
                 if not db_file:
-                    raise ValueError(
-                        f"could not extract vulnerability.db from {archive_path!r}"
-                    )
+                    raise ValueError(f"could not extract vulnerability.db from {archive_path!r}")
 
                 while chunk := db_file.read(8192):
                     hasher.update(chunk)

--- a/src/yardstick/utils/__init__.py
+++ b/src/yardstick/utils/__init__.py
@@ -49,9 +49,7 @@ def dig(target, *keys, **kwargs):
     """
     end_of_chain = target
     for key in keys:
-        if (isinstance(end_of_chain, dict) and key in end_of_chain) or (
-            isinstance(end_of_chain, (list, tuple)) and isinstance(key, int)
-        ):
+        if (isinstance(end_of_chain, dict) and key in end_of_chain) or (isinstance(end_of_chain, (list, tuple)) and isinstance(key, int)):
             end_of_chain = end_of_chain[key]
         else:
             if "fail" in kwargs and kwargs["fail"] is True:

--- a/src/yardstick/validate/gate.py
+++ b/src/yardstick/validate/gate.py
@@ -61,10 +61,7 @@ class Gate:
                 f"current F1 score is lower than the latest release F1 score: candidate_score={current_f1_score:0.2f} reference_score={reference_f1_score:0.2f} image={self.input_description.image}"
             )
 
-        if (
-            candidate_comparison.indeterminate_percent
-            > self.config.max_unlabeled_percent
-        ):
+        if candidate_comparison.indeterminate_percent > self.config.max_unlabeled_percent:
             reasons.append(
                 f"current indeterminate matches % is greater than {self.config.max_unlabeled_percent}%: candidate={candidate_comparison.indeterminate_percent:0.2f}% image={self.input_description.image}"
             )

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -132,9 +132,7 @@ test_profile:
 )
 def test_is_valid_oci_reference(name, image, expected_valid):
     result = config.ScanMatrix.is_valid_oci_reference(image)
-    assert (
-        result == expected_valid
-    ), f"Test case {name}: Expected {expected_valid} but got {result} for image '{image}'"
+    assert result == expected_valid, f"Test case {name}: Expected {expected_valid} but got {result} for image '{image}'"
 
 
 @pytest.mark.parametrize(
@@ -194,6 +192,4 @@ def test_is_valid_oci_reference(name, image, expected_valid):
 )
 def test_parse_oci_reference(image, expected_output):
     result = config.ScanMatrix.parse_oci_reference(image)
-    assert (
-        result == expected_output
-    ), f"Expected {expected_output} but got {result} for image '{image}'"
+    assert result == expected_output, f"Expected {expected_output} but got {result} for image '{image}'"

--- a/tests/unit/test_artifact.py
+++ b/tests/unit/test_artifact.py
@@ -164,14 +164,8 @@ def test_scan_configuration():
     assert s.image == "docker.io/place/ubuntu@sha256:123"
     assert s.image_encoded == "docker.io+place+ubuntu@sha256:123"
     assert s.image_repo_encoded == "docker.io+place+ubuntu"
-    assert (
-        s.path
-        == "docker.io/place/ubuntu@sha256:123/grype@main/2022-09-06T16:07:01.138937+00:00"
-    )
-    assert (
-        s.encoded_path
-        == "docker.io+place+ubuntu@sha256:123/grype@main/2022-09-06T16:07:01.138937+00:00"
-    )
+    assert s.path == "docker.io/place/ubuntu@sha256:123/grype@main/2022-09-06T16:07:01.138937+00:00"
+    assert s.encoded_path == "docker.io+place+ubuntu@sha256:123/grype@main/2022-09-06T16:07:01.138937+00:00"
 
 
 def test_dt_encoder():

--- a/tests/unit/tool/test_grype.py
+++ b/tests/unit/tool/test_grype.py
@@ -68,9 +68,7 @@ def test_install_from_path():
         git_describe_val = "v0.65.1-1-g74a7a67-dirty"
         hash_of_git_diff = "a29864cf5600b481056b6fa30a21cdbabc15287d"[:8]
         fake_repo.git.describe.return_value = git_describe_val
-        fake_repo.git.diff.return_value = (
-            "test-diff"  # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
-        )
+        fake_repo.git.diff.return_value = "test-diff"  # hash is 'a29864cf5600b481056b6fa30a21cdbabc15287d'
         repo.return_value = fake_repo
         version_str = "path:/where/grype/is/cloned"
         normalized_version_str = version_str.replace("/", "_").removeprefix("path:")

--- a/tests/unit/validate/test_delta.py
+++ b/tests/unit/validate/test_delta.py
@@ -98,17 +98,13 @@ def test_delta_properties(
 @pytest.fixture
 def reference_result():
     """Fixture for creating a mock reference result."""
-    return MagicMock(
-        name="reference_results", ID="reference", config=MagicMock(tool="reference")
-    )
+    return MagicMock(name="reference_results", ID="reference", config=MagicMock(tool="reference"))
 
 
 @pytest.fixture
 def candidate_result():
     """Fixture for creating a mock candidate result."""
-    return MagicMock(
-        name="candidate_results", ID="candidate", config=MagicMock(tool="candidate")
-    )
+    return MagicMock(name="candidate_results", ID="candidate", config=MagicMock(tool="candidate"))
 
 
 @pytest.fixture

--- a/tests/unit/validate/test_gate.py
+++ b/tests/unit/validate/test_gate.py
@@ -39,9 +39,7 @@ def mock_label_comparison():
             ),
             MagicMock(f1_score=0.9, false_negatives=5, indeterminate_percent=2.0),
             MagicMock(f1_score=0.85, false_negatives=7, indeterminate_percent=2.0),
-            [
-                "current false negatives is greater than the latest release false negatives"
-            ],
+            ["current false negatives is greater than the latest release false negatives"],
         ),
         # Case 3: Candidate has too high indeterminate percent -> gate fails
         (

--- a/tests/unit/validate/test_validate.py
+++ b/tests/unit/validate/test_validate.py
@@ -38,9 +38,7 @@ def compare_results_identical_matches():
 
 
 @patch("yardstick.compare_results")
-def test_validate_fail_on_empty_matches(
-    mock_compare_results, compare_results_no_matches
-):
+def test_validate_fail_on_empty_matches(mock_compare_results, compare_results_no_matches):
     mock_compare_results.return_value = compare_results_no_matches
     gate = validate_image(
         "some image",
@@ -50,9 +48,7 @@ def test_validate_fail_on_empty_matches(
         verbosity=0,
     )
     assert not gate.passed()
-    assert (
-        "gate configured to fail on empty matches, and no matches found" in gate.reasons
-    )
+    assert "gate configured to fail on empty matches, and no matches found" in gate.reasons
     mock_compare_results.assert_called_once_with(
         descriptions=["some-str", "another-str"],
         year_max_limit=None,
@@ -61,9 +57,7 @@ def test_validate_fail_on_empty_matches(
 
 
 @patch("yardstick.compare_results")
-def test_validate_dont_fail_on_empty_matches(
-    mock_compare_results, compare_results_no_matches
-):
+def test_validate_dont_fail_on_empty_matches(mock_compare_results, compare_results_no_matches):
     mock_compare_results.return_value = compare_results_no_matches
     gate = validate_image(
         "some image",
@@ -81,9 +75,7 @@ def test_validate_dont_fail_on_empty_matches(
 
 
 @patch("yardstick.compare_results")
-def test_validate_pass_early_identical_match_sets(
-    mock_compare_results, compare_results_identical_matches
-):
+def test_validate_pass_early_identical_match_sets(mock_compare_results, compare_results_identical_matches):
     mock_compare_results.return_value = compare_results_identical_matches
     gate = validate_image(
         "some image",


### PR DESCRIPTION
Add a make target `make format` that runs `ruff format src tests`, and call it during pre-commit. The rest of the diff is auto-generated, with the exception that ruff format put an existing `type: ignore[attr-defined]` on the wrong line when splitting up a line that was too long.

Most of the auto generated diff is line length changes. I'm happy to move the line length configured in `tool.ruff.line-length` in the pyproject.toml to try to reduce the diff size, but for a first draft I just left it what it was.