### PR TITLE
Update dependabot config + deprecated actions/cache dependency

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -33,7 +33,7 @@ runs:
     - name: Restore tool cache
       if: inputs.tools == 'true'
       id: tool-cache
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: ${{ github.workspace }}/.tool
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-tool-${{ hashFiles('.binny.yaml') }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,18 @@
 version: 2
 updates:
+
   - package-ecosystem: "github-actions"
-    directory: "/"
+    open-pull-requests-limit: 10
+    directory: "/.github/actions/bootstrap"
     schedule:
-      interval: daily
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    open-pull-requests-limit: 10
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR remediates the following issue seen on release:
```
release-pypi    Bootstrap environment   2025-03-03T21:10:52.1653866Z ##[error]This request has been automatically failed because it uses a deprecated version of `actions/cache: 704facf57e6136b1bc63b828d79edcd491f0ee84`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

As well as updates the dependabot config to (hopefully) cover these cases.