### PR TITLE
Fix using profiles and labels together

### DIFF
--- a/src/yardstick/artifact.py
+++ b/src/yardstick/artifact.py
@@ -135,6 +135,18 @@ class ScanConfiguration:
         self.image_repo = self.image_repo.replace("+", "/")
 
     @property
+    def raw_tool_name(self):
+        # given anything like "grype[label]" return "grype"
+        if "[" in self.tool_name:
+            return self.tool_name.split("[", 1)[0]
+
+        # given anything like "grype@v0.30.0+linux" return "grype"
+        if "@" in self.tool_name:
+            return self.tool_name.split("@", 1)[0]
+
+        return self.tool_name
+
+    @property
     def path(self):
         return f"{self.image_repo}@{self.image_digest}/{self.tool}/{self.timestamp_rfc3339}"
 

--- a/src/yardstick/capture.py
+++ b/src/yardstick/capture.py
@@ -118,9 +118,10 @@ def one(
 
     profile_obj = None
     if request.profile:
-        profile_obj = profiles.get(scan_config.tool_name, {}).get(request.profile, {})
+        tool_name = scan_config.raw_tool_name
+        profile_obj = profiles.get(tool_name, {}).get(request.profile, {})
         if not profile_obj:
-            raise RuntimeError(f"no profile found for tool {scan_config.tool_name}")
+            raise RuntimeError(f"no profile found for tool {tool_name}")
 
     match_results, raw_json = run_scan(config=scan_config, profile=profile_obj)
     store.scan_result.save(

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1071,7 +1072,6 @@ wheels = [
 
 [[package]]
 name = "yardstick"
-version = "0.12.1.post2+2fb68de"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Today if you use both configuration profiles and tool labels together then the profile fetch will fail (since it embeds the tool name). This PR allows access to the raw tool name for profile fetching.