### PR TITLE
Tighten workflow security, update release shape, dependabot, and add CodeQL

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,3 +1,5 @@
+cooldown: 7d
+
 tools:
   # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,25 +2,20 @@ version: 2
 updates:
 
   - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     open-pull-requests-limit: 10
-    directory: "/.github/actions/bootstrap"
     schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 10
-    directory: "/.github/workflows"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
 
   - package-ecosystem: "uv"
     directory: "/"
+    open-pull-requests-limit: 10
     schedule:
-      interval: daily
+      interval: "weekly"
     cooldown:
       default-days: 7
     groups:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,62 @@
+# CodeQL scans for security vulnerabilities and coding errors across all
+# languages in this repo. Results appear in the "Security" tab under
+# "Code scanning alerts" and are enforced by branch protection rules.
+name: "CodeQL"
+
+permissions: {}
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  # Weekly scheduled scan catches newly disclosed vulnerabilities in
+  # existing code, not just changes introduced by PRs.
+  schedule:
+    - cron: "38 11 * * 3"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the "Security" tab.
+      security-events: write
+      # Required to fetch internal or private CodeQL packs.
+      packages: read
+      # Only required for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # GitHub Actions workflow linting — no build needed.
+          - language: actions
+            build-mode: none
+
+          # Python uses "none" build mode since it is an interpreted language
+          # and does not require compilation for CodeQL analysis.
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          # The category tag lets GitHub associate SARIF results with the
+          # correct language when branch protection checks for required
+          # code scanning results.
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,12 @@
 name: "Release"
+
+permissions: {}
+
+# there should never be two releases in progress at the same time
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,56 +14,25 @@ on:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
 
-permissions:
-  contents: read
-
 jobs:
 
-  quality-gate:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Check if tag already exists
-        # note: this will fail if the tag already exists
-        env:
-          VERSION_INPUT: ${{ github.event.inputs.version }}
-        run: |
-          # Validate version format (v followed by semver)
-          if [[ ! "$VERSION_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-            echo "Invalid version format: $VERSION_INPUT (expected format: vX.Y.Z)"
-            exit 1
-          fi
-          git tag "$VERSION_INPUT"
+  version-available:
+    uses: anchore/workflows/.github/workflows/check-version-available.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      version: ${{ github.event.inputs.version }}
 
-      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
-      - name: Ensure tagged commit is on main
-        run: |
-          echo "Tag: ${GITHUB_REF##*/}"
-          git fetch origin main
-          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
-
-      - name: Check validation results
-        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be # v1.2.0
-        id: validations
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/validations.yaml)
-          checkName: "validations"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: steps.validations.conclusion != 'success'
-        env:
-          VALIDATION_STATUS: ${{ steps.validations.conclusion }}
-        run: |
-          echo "Validations Status: $VALIDATION_STATUS"
-          false
+  check-gate:
+    permissions:
+      checks: read   # required for getting the status of specific check names
+    uses: anchore/workflows/.github/workflows/check-gate.yaml@8b2b1caf40e03933c6807e03b99e883e2ceb5ac8 # v0.4.0
+    with:
+      # these are checks that should be run on pull-request and merges to main.
+      # we do NOT want to kick off a release if these have not been verified on main.
+      # Please see the validations.yaml workflow for the names that should be used here.
+      checks: '["validations"]'
 
   tag:
-    needs:
-      - quality-gate
+    needs: [check-gate, version-available]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -6,14 +6,15 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
 
   # note: changing the job name requires a quality gate reference change in .github/workflows/release.yaml
   validations:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Brings the repo into line with org-wide CI/workflow standards. Moves
workflow-level permissions to `{}` with scoped permissions at the job level,
replaces the hand-rolled quality gate with the canonical reusable check-gate
workflow, tightens dependabot update schedules, adds a binny cooldown, and
introduces a CodeQL workflow.

Changes:
- release.yaml: replace custom quality-gate job with version-available + check-gate reusable workflows; add concurrency group; set top-level permissions: {}
- validate-github-actions.yaml, validations.yaml: top-level permissions: {}; contents: read pushed to job level
- dependabot.yml: github-actions and uv ecosystems set to weekly; github-actions now covers both / and /.github/actions/*; uv gains open-pull-requests-limit
- .binny.yaml: add top-level cooldown: 7d
- codeql.yaml: new CodeQL workflow scanning Python and GitHub Actions

Notes:
- attestation steps and secrets-outside-env findings are deferred and not addressed here