### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip pre-release checks (check-gate)
+        type: boolean
+        default: false
 
 jobs:
   version-available:
@@ -23,7 +27,9 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    if: ${{ !inputs.skip-checks }}
     permissions:
+      contents: read # required for the reusable workflow to check out the repo
       checks: read # required for getting the status of specific check names
     uses: anchore/workflows/.github/workflows/check-gate.yaml@b0c30a80409130d329aaa356fd64a34d8c0b3375 # v0.7.2
     with:
@@ -34,6 +40,14 @@ jobs:
 
   tag:
     needs: [check-gate, version-available]
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -43,11 +57,12 @@ jobs:
           # in order to properly resolve the version from git
           fetch-depth: 0
           persist-credentials: true
+          # for pushing tags (does not inherit workflow permissions)
+          token: ${{ secrets.TAG_TOKEN }}
 
       - name: Tag release
         env:
           VERSION_INPUT: ${{ github.event.inputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "anchoreci"
           git config --global user.email "anchoreci@users.noreply.github.com"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,1 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
+rules: {}


### PR DESCRIPTION
quick pass refactoring yardstick's release CI (python project, so the go-specific bits don't apply):

- dropped dependabot grouping so updates come as individual PRs
- zizmor.yml trimmed to `rules: {}` (removed the unpinned-uses config)
- added a skip-checks workflow_dispatch input and made check-gate skippable; the tag job now runs even when check-gate is skipped but still requires version-available to pass
- gave check-gate the contents: read permission it was missing
- switched the tag job to push tags with TAG_TOKEN (via the checkout token) instead of the default GITHUB_TOKEN, so it doesn't inherit workflow permissions